### PR TITLE
removed external parameter name for CocktailIngredient initializer 

### DIFF
--- a/MetaCocktailsSwiftData/Cocktails/Classics/AperolSpritz.swift
+++ b/MetaCocktailsSwiftData/Cocktails/Classics/AperolSpritz.swift
@@ -18,9 +18,9 @@ var aperolSpritz = Cocktail(cocktailName: "Aperol Spritz",
                             tags: aperolSpritzTags)
 
 
-var aperolSpritzSpec = [CocktailIngredient(ingredient: .aperol, value: 2),
-                        CocktailIngredient(ingredient: .prosecco, value: 3),
-                        CocktailIngredient(ingredient: .sparklingWater, value: 1)]
+var aperolSpritzSpec = [CocktailIngredient(.aperol, value: 2),
+                        CocktailIngredient(.prosecco, value: 3),
+                        CocktailIngredient(.sparklingWater, value: 1)]
 
 
 var aperolSpritzBuild = Build(instructions: [Instruction(step: 1, method: "Add all ingredients to the wine glass"),

--- a/MetaCocktailsSwiftData/Cocktails/Classics/Daiquiri.swift
+++ b/MetaCocktailsSwiftData/Cocktails/Classics/Daiquiri.swift
@@ -9,9 +9,9 @@ import Foundation
 
 let daiquiri = Cocktail(cocktailName: "Daiquiri", glasswareType: .coupe, garnish: [.limeWheel], spec: daiquiriSpec, tags: daiquiriTags)
 
-var daiquiriSpec: [CocktailIngredient] = [CocktailIngredient(ingredient: .whiteRum, value: 2.0),
-                                          CocktailIngredient(ingredient: .lime, value: 0.75),
-                                          CocktailIngredient(ingredient: .simple, value: 0.75)]
+var daiquiriSpec: [CocktailIngredient] = [CocktailIngredient(.whiteRum, value: 2.0),
+                                          CocktailIngredient(.lime, value: 0.75),
+                                          CocktailIngredient(.simple, value: 0.75)]
 
 var daiquiriTags = Tags(flavors: [.lime],
                 profiles: [.citrusy],

--- a/MetaCocktailsSwiftData/Cocktails/Classics/RamosGinFizz.swift
+++ b/MetaCocktailsSwiftData/Cocktails/Classics/RamosGinFizz.swift
@@ -15,14 +15,14 @@ var ramosTags = Tags(flavors: [.cream, .lemon, .lime],
                      styles: [.sour],
                      bases: [.gin])
 
-let ramosGinFizzSpec: [CocktailIngredient]         = [CocktailIngredient(ingredient: .gin, value: 2.0),
-                                                     CocktailIngredient(ingredient: .lime, value: 0.5),
-                                                     CocktailIngredient(ingredient: .lemon, value: 0.5),
-                                                     CocktailIngredient(ingredient: .simple, value: 1.0),
-                                                     CocktailIngredient(ingredient: .cream, value: 1.0),
-                                                     CocktailIngredient(ingredient: .eggWhites, value: 1.25),
-                                                     CocktailIngredient(ingredient: .sodaWater, value: 2.0),
-                                                     CocktailIngredient(ingredient: .orangeFlowerWater, value: 1, unit: .dash)]
+let ramosGinFizzSpec: [CocktailIngredient]         = [CocktailIngredient(.gin, value: 2.0),
+                                                     CocktailIngredient(.lime, value: 0.5),
+                                                     CocktailIngredient(.lemon, value: 0.5),
+                                                     CocktailIngredient(.simple, value: 1.0),
+                                                     CocktailIngredient(.cream, value: 1.0),
+                                                     CocktailIngredient(.eggWhites, value: 1.25),
+                                                     CocktailIngredient(.sodaWater, value: 2.0),
+                                                     CocktailIngredient(.orangeFlowerWater, value: 1, unit: .dash)]
 
 
 var ramosGinFizzBuild: Build = Build(instructions: [Instruction(step: 1, method: "Chill your 14oz. collins glass ahead of time"),

--- a/MetaCocktailsSwiftData/Cocktails/ModernClassics/BlackberrySageSmash.swift
+++ b/MetaCocktailsSwiftData/Cocktails/ModernClassics/BlackberrySageSmash.swift
@@ -11,11 +11,11 @@ var blackberrySageSmash = Cocktail(cocktailName: "Blackberry Sage Smash", imageA
 
 let blackberrySageSmashTags = Tags(flavors: [.lemon], profiles: [.fruity], textures: [.light], styles: [.sour], bases: [.ryeWhiskey])
 
-let blackberrySageSmashSpec: [CocktailIngredient] = [CocktailIngredient(ingredient: .ryeWhiskey, value: 2),
-                                                     CocktailIngredient(ingredient: .lemon, value: 0.75),
-                                                     CocktailIngredient(ingredient: .simple, value: 0.75),
-                                                     CocktailIngredient(ingredient: .blackBerry, value: 4, unit: .berries),
-                                                     CocktailIngredient(ingredient: .sage, value: 4, unit: .leaves)]
+let blackberrySageSmashSpec: [CocktailIngredient] = [CocktailIngredient(.ryeWhiskey, value: 2),
+                                                     CocktailIngredient(.lemon, value: 0.75),
+                                                     CocktailIngredient(.simple, value: 0.75),
+                                                     CocktailIngredient(.blackBerry, value: 4, unit: .berries),
+                                                     CocktailIngredient(.sage, value: 4, unit: .leaves)]
 
 let blackberrySageSmashBuild =  Build(instructions: [Instruction(step: 1, method: "In a tin, muddle 4 blackberries and a small pinch of sage."),
                                                      Instruction(step: 2, method: "Add your ingredients and shake with ice."),

--- a/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
@@ -18,7 +18,7 @@ class CocktailIngredient {
     let value: Double
     let unit: MeasurementUnit
     
-    init(ingredient: Ingredient, value: Double, unit: MeasurementUnit = .fluidOunces) {
+    init(_ ingredient: Ingredient, value: Double, unit: MeasurementUnit = .fluidOunces) {
         self.ingredient = ingredient
         self.value = value
         self.unit = unit


### PR DESCRIPTION
Made a little change that will make creating cocktail ingredient arrays less tedious

### Before
![Xnip2023-10-16_16-50-54](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/96077863/e5268128-75d2-4b42-9384-09f284ddfca5)

### After
![Xnip2023-10-16_16-50-46](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/96077863/78c29b5f-1a33-4561-8e82-6d85fcd0d446)
