### PR TITLE
Added dummy cocktails.

### DIFF
--- a/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
+++ b/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		1AFDB7DE2AE37207000A3812 /* Boulevardier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFDB7DD2AE37207000A3812 /* Boulevardier.swift */; };
 		1AFDB7E02AE37417000A3812 /* WhiteNegroni.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFDB7DF2AE37417000A3812 /* WhiteNegroni.swift */; };
 		4D09E65F2B146B9500D38C35 /* Saturn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D09E65E2B146B9500D38C35 /* Saturn.swift */; };
+		4D09E6612B1EDFA100D38C35 /* SearchViewRecipeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D09E6602B1EDFA100D38C35 /* SearchViewRecipeCard.swift */; };
 		F41045072AD4FD42000CA913 /* CocktailImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F41045062AD4FD42000CA913 /* CocktailImageView.swift */; };
 		F44A28F72AC26A6A0083C04D /* TagLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44A28F62AC26A6A0083C04D /* TagLayout.swift */; };
 		F4B0ABF32B13FB2A00336D05 /* SearchResultsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B0ABF22B13FB2A00336D05 /* SearchResultsView.swift */; };
@@ -160,6 +161,7 @@
 		1AFDB7DD2AE37207000A3812 /* Boulevardier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Boulevardier.swift; sourceTree = "<group>"; };
 		1AFDB7DF2AE37417000A3812 /* WhiteNegroni.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhiteNegroni.swift; sourceTree = "<group>"; };
 		4D09E65E2B146B9500D38C35 /* Saturn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Saturn.swift; sourceTree = "<group>"; };
+		4D09E6602B1EDFA100D38C35 /* SearchViewRecipeCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewRecipeCard.swift; sourceTree = "<group>"; };
 		F41045062AD4FD42000CA913 /* CocktailImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CocktailImageView.swift; sourceTree = "<group>"; };
 		F44A28F62AC26A6A0083C04D /* TagLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TagLayout.swift; sourceTree = "<group>"; };
 		F4B0ABF22B13FB2A00336D05 /* SearchResultsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchResultsView.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 			children = (
 				1AC3869C2AAABED00064F52A /* RecipeCard.swift */,
 				1AC3869D2AAABED00064F52A /* RecipeIngredientsView.swift */,
+				4D09E6602B1EDFA100D38C35 /* SearchViewRecipeCard.swift */,
 			);
 			path = "Recipe View";
 			sourceTree = "<group>";
@@ -598,6 +601,7 @@
 				1AFDB7C22AE32F2E000A3812 /* RobRoy.swift in Sources */,
 				1AFDB7C82AE33287000A3812 /* UltimaPalabra.swift in Sources */,
 				F4DBE4C52AB8831C009A0C09 /* AnimatedSearchView.swift in Sources */,
+				4D09E6612B1EDFA100D38C35 /* SearchViewRecipeCard.swift in Sources */,
 				1AC386CA2AAABED10064F52A /* CocktailListViewModel.swift in Sources */,
 				F4C74C812AD8CC3300EA3334 /* AperolSpritz.swift in Sources */,
 				1AC386BB2AAABED10064F52A /* Glassware.swift in Sources */,

--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
@@ -15,4 +15,8 @@ final class CocktailListViewModel: ObservableObject {
     @Published var isShowingRecipeCard = false
     @Published var selectedCocktail: Cocktail?
     @Published var isShowingBuildOrderButton = false
+    
+    @Published var sampleCocktails: [Cocktail] = [penicillin, boulevardier, cominUpRoses, cosmopolitan]
+    @Published var secondarySampleCocktails: [Cocktail] = [cloverClub, lastWord, caipirinha]
+    @Published var thirdondarySampleCocktails: [Cocktail] = [whiteNegroni]
 }

--- a/MetaCocktailsSwiftData/Views/Recipe View/SearchViewRecipeCard.swift
+++ b/MetaCocktailsSwiftData/Views/Recipe View/SearchViewRecipeCard.swift
@@ -1,0 +1,44 @@
+//
+//  SearchViewRecipeCard.swift
+//  MetaCocktailsSwiftData
+//
+//  Created by James Menkal on 12/4/23.
+//
+import SwiftUI
+
+struct SearchViewRecipeCard: View {
+    
+    @State var cocktail: Cocktail
+
+
+    @State private var isShowingBuildOrder = false
+
+    var body: some View {
+        
+        VStack {
+
+            Spacer()
+
+//            cocktail.image
+
+            VStack {
+
+               RecipeIngredientsView(cocktail: cocktail)
+                    .fontWeight(.semibold)
+            }
+
+   
+            Spacer()
+        }
+     
+    }
+    
+        
+}
+
+struct SearchViewRecipeCard_Previews: PreviewProvider {
+    static var previews: some View {
+        SearchViewRecipeCard(cocktail: aperolSpritz)
+    }
+}
+

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaView.swift
@@ -14,6 +14,7 @@ struct SearchCriteriaView: View {
     @State var selectedList: PreferenceType = .all
     @State var isShowingPreferences: Bool
     @State var selectedLikesOrDislikes: LikesOrDislikes = .likes
+   
     
     var body: some View {
         NavigationStack {
@@ -57,6 +58,7 @@ struct SearchCriteriaView: View {
                 } label: {
                     Text("Show Preferred Cocktails")
                 }
+               
 
                 ListView(selectedList: $selectedList, navigationTitle: selectedList.getTitle(), isShowingLikes: $isShowingPreferences)
                 

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -12,6 +12,8 @@ final class SearchCriteriaViewModel: ObservableObject {
     @Published var searchText: String = ""
     @Published var cocktailComponents = Tags.createComponentArray()
     
+    var selectedTagExamples: [String] = ["lemon", "ginger", "chocolate"]
+    
     func matchAllTheThings() {
         // if searchText is empty, show everything again
         

--- a/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
@@ -10,7 +10,9 @@ import SwiftUI
 struct SearchResultsView: View {
     
     var viewModel: SearchCriteriaViewModel
-
+  
+    //var searchedCocktails: [Cocktail]
+    
     
     //    ALL THESE PROPERTIES CAN LIVE IN THE VIEWMODEL EVENTUALLY, BUT THEY'RE HERE FOR NOW.
     
@@ -21,10 +23,11 @@ struct SearchResultsView: View {
     //    @State private var  unwantedTags = Tags(flavors: [.almond])
         
 
+    // create this as an array ion the viewmodel and access it from the view model. Also do the same thing but for cocktails.
     
-    @State private var selectedTagExamples: [String] = ["lemon", "ginger", "chocolate"] // placeholders for example.
+ // @State private var selectedTagExamples: [String] = ["lemon", "ginger", "chocolate"] // placeholders for example.
 
-    
+    //let sampleCocktails = CocktailListViewModel().sampleCocktails
     var body: some View {
         
         VStack(alignment: .leading) {
@@ -38,14 +41,16 @@ struct SearchResultsView: View {
             
             ScrollView(.horizontal) {
                 HStack(spacing: 12) {
-                    ForEach(selectedTagExamples, id: \.self) { tag in
+                    ForEach(viewModel.selectedTagExamples, id: \.self) { tag in
                         TagView(tag, .green, "xmark")
 //                            .matchedGeometryEffect(id: tag, in: animation)
                         // removing from selected list on tap
                             .onTapGesture {
-                                withAnimation(.snappy) {
-                                    selectedTagExamples.removeAll(where: { $0 == tag })
+                                withAnimation(.bouncy) {
+                                    viewModel.selectedTagExamples.removeAll(where: {$0 == tag})
+                                       
                                 }
+                                
                             }
                     }
                 }
@@ -58,21 +63,41 @@ struct SearchResultsView: View {
             
             List {
                 Section(header: SearchedCocktailTitleHeader(searched: 5, matched: 5)) {
-                    SearchedCocktailCell()
-                    SearchedCocktailCell()
+                    
+                    ForEach(CocktailListViewModel().sampleCocktails, id: \.self) { sampleCocktail in
+                        NavigationLink {
+                            SearchViewRecipeCard(cocktail: sampleCocktail)
+                        } label: {
+                           Text(sampleCocktail.cocktailName)
+                        }
+                    }
+                    
+                    
                 }
                 
                 
                 Section(header: SearchedCocktailTitleHeader(searched: 5, matched: 4)) {
-                    SearchedCocktailCell()
-
+                    ForEach(CocktailListViewModel().secondarySampleCocktails, id: \.self) { sampleCocktail in
+                        NavigationLink {
+                            SearchViewRecipeCard(cocktail: sampleCocktail)
+                        } label: {
+                           Text(sampleCocktail.cocktailName)
+                        }
+                    }
                 }
                 
                 Section(header: SearchedCocktailTitleHeader(searched: 5, matched: 3)) {
-                    SearchedCocktailCell()
+                    ForEach(CocktailListViewModel().thirdondarySampleCocktails, id: \.self) { sampleCocktail in
+                        NavigationLink {
+                            SearchViewRecipeCard(cocktail: sampleCocktail)
+                        } label: {
+                           Text(sampleCocktail.cocktailName)
+                        }
+                    }
 
                 }
             }
+            
             .listStyle(.grouped)
         }
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
I also put the selectedTagExamples in the SearchCriteriaViewModel as requested.

This has caused the animation to not work. 

The reason the animation doesn't work is because the array is owned by the view model and not by the var on the SearchResultsView.

Every time you click on the tag to dismiss it, its refreshing the parent view that owns the array, not the current view. Hence, you don't see the page refresh. Though, the array is still getting changed. 

Because of this, you can click on the tags to try to remove them, but you won't get to see them removed until you leave the page and go back to the SearchResultsView manually. Then, you'll see that they've been deleted from the array. 

I don't currently know a work around for this. 
