### PR TITLE
Made getFilteredCocktail methods an extension, then moved them back to model file

### DIFF
--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -172,210 +172,209 @@ final class SearchCriteriaViewModel: ObservableObject {
         }
         return baseArray
     }
-    
-    
-    
-    
-    // MARK: MOVED TO SEARCH-RESULTS-VIEW ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~``````````````````~~~~~~~~~~~~~~~~~`````````````````~~~~~~~~~~~~~~~~~`````````````````~~~~~~~~~~~~~~~~`````````````````~~~~~~~~~~~~~~~~``````````````` ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//    func removePreference(for component: CocktailComponent) {
-//        // When we click a green bubble to remove a preferred tag, we change the data and the UI updates.
-//        
-//        preferredCount -= 1
-//        let cocktailComponent = cocktailComponents.filter ({ $0.id == component.id })
-//        cocktailComponent.first?.isPreferred = false
-//        getFilteredCocktails()
-//    }
-//    
-//    func removeUnwanted(for component: CocktailComponent) {
-//        // When we click a red bubble to remove an unwanted tag, we change the data and the UI updates.
-//        let cocktailComponent = cocktailComponents.filter ({ $0.id == component.id })
-//        cocktailComponent.first?.isUnwanted = false
-//        getFilteredCocktails()
-//    }
-//    
-//    func filterUnwantedCocktails(cocktailComponentArray: [CocktailComponent], cocktails: [Cocktail]) -> [Cocktail] {
-//         cocktails.filter { cocktail in
-//             cocktailComponentArray.allSatisfy { unwantedComponent in
-//                !convertTagsAndSpecToStrings(for: cocktail).contains(unwantedComponent.name)
-//            }
-//        }
-//    }
-//    
-//    func countMatches(_ currentCount: Int, for preferredComponent: CocktailComponent, in cocktail: Cocktail) -> Int {
-//        // compare preferredComponent against current cocktail of loop, then return number of matches.
-//        var matches = currentCount
-//        if convertTagsAndSpecToStrings(for: cocktail).contains(preferredComponent.name){
-//            matches += 1
-//        }
-//        return matches
-//    }
-//    
-//    
-//    
-//    func convertTagsAndSpecToStrings(for cocktail: Cocktail) -> [String] {
-//        var strings: [String] = [String]()
-//        strings.append(contentsOf: cocktail.spec.map({$0.ingredient.name}))
-//        if let booze = cocktail.compiledTags.booze {
-//            strings.append(contentsOf: booze.map({$0.name}))
-//        }
-//        if let flavors = cocktail.compiledTags.flavors {
-//            strings.append(contentsOf: flavors.map({$0.rawValue}))
-//        }
-//        if let styles = cocktail.compiledTags.styles {
-//            strings.append(contentsOf: styles.map({$0.rawValue}))
-//        }
-//        if let profiles = cocktail.compiledTags.profiles {
-//            strings.append(contentsOf: profiles.map({$0.rawValue}))
-//        }
-//        if let nA = cocktail.compiledTags.nA {
-//            strings.append(contentsOf: nA.map({$0.name}))
-//        }
-//        return Array(Set(strings))
-//    }
-//    //                                                              MARK: We need to change this to utilize SwiftData @Query
-//    func getFilteredCocktails() {
-//        var startingCocktails: [Cocktail] = []
-//        isLoading = true
-//        resetSearchCriteria()
-//        if returnPreferredBaseSpirits().count > 1 {
-//            multipleBaseSpiritsSelected = true
-//        } else {
-//            multipleBaseSpiritsSelected = false
-//        }
-//       
-//
-//        /** First, loop over every cocktail and add any cocktails that don't match any unwanted preferences to create the StartingCocktails array. */
-//        /// Start with the appropriate set of cocktails for the corresponding mode
-//        ///
-//        
-//        startingCocktails = filterUnwantedCocktails(cocktailComponentArray: selectedUnwantedIngredients(), cocktails: CocktailListViewModel().bartenderCocktails)
-//        
-//        
-//        if showWilliamsAndGrahamCocktails {
-//            startingCocktails = filterUnwantedCocktails(cocktailComponentArray: selectedUnwantedIngredients(), cocktails: CocktailListViewModel().justWilliamsAndGrahamCocktails)
-//        }
-//        
-//        /**loop over the number of preferredCount / 2 and create ResultViewSectionData objects with count and matched numbers filled in but empty cocktail arrays.
-//        Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
-//        let finalMatchContainers: [ResultViewSectionData] = {
-//            var dataShells = [ResultViewSectionData]()
-//            if enableMultipleSpiritSelection == true {
-//                /** If we're searching for separate base spirits, we need to add more shells. One for each base spirit searched in each match number about 50%. We also need to use a modified preferredCount that counts all spirits as a total of one. */
-//                preferredCount = modifiedPreferredCount()
-//                for i in 0...Int(preferredCount / 2) {
-//                    let numberOfMatches = (preferredCount - i)
-//                    for spirit in returnPreferredBaseSpirits() {
-//                        dataShells.append(ResultViewSectionData(count: preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
-//                    }
-//                }
-//                return dataShells
-//            } else {
-//                /**Otherwise search normaly, allowing individual base spirits to add to the total search count.**/
-//                preferredCount = selectedPreferredIngredients().count
-//                for i in 0...Int(preferredCount / 2) {
-//                    let numberOfMatches = (preferredCount - i)
-//                    dataShells.append(ResultViewSectionData(count: preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: []))
-//                }
-//                return dataShells
-//            }
-//        }()
-//        /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
-//        for cocktail in startingCocktails {
-//            
-//            /** We use let _ = ... to loop over finalMatchContainers to append cocktails that match preferred components to the right section without creating a new array in the process */
-//            let _ = finalMatchContainers.map { resultViewSectionData in
-//                
-//            /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
-//                if enableMultipleSpiritSelection == false {
-//                    if resultViewSectionData.matched == selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
-//                        resultViewSectionData.cocktails.append(cocktail)
-//                    }
-//                } else {
-//                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
-//                            resultViewSectionData.cocktails.append(cocktail)
-//                        //print("the count match for \(cocktail.cocktailName) is \(countMatchesForMultipleSpirits(for: cocktail))")
-//                    }
-//                }
-//            }
-//        }
-//        
-//        /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
-//        sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
-//         
-//        /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
-//                i.e.
-//            sections = finalMatchContainers.compactMap { resultSectionData in
-//            return resultSectionData.cocktails.isEmpty ? nil : resultSectionData } */
-//
-//        isLoading = false
-//        print("The cocktail count is \(CocktailListViewModel().bartenderCocktails.count)")
-//    }
-//    
-//    //                                                                                          MARK: For loops
-//    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
-//        // compare preferredComponent against current cocktail of loop, then return number of matches.
-//        var justBases = [String]()
-//        var alreadyMatchedSpec = 0
-//        if let booze = cocktail.compiledTags.booze {
-//            for booze in booze {
-//                if !baseSpiritsConvertedIntoStrings.contains(booze.name) {
-//                    justBases.append(booze.name)
-//                }
-//            }
-//        }
-//        // FUNCTION NEED ACCESS TO VIEW MODEL
-//        let matches = cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
-//            for spec in justBases {
-//                if spec == component.name && alreadyMatchedSpec == 0 {
-//                    partialResult += 1
-//                    alreadyMatchedSpec += 1
-//                }
-//            }
-//            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
-//                    partialResult += 1
-//                }
-//        })
-//        return matches
-//    }
-//
-//    //                                                                                          MARK: For loops
-//    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
-//        var strings: [String] = [String]()
-//        if let boozeComponents = tags.booze {
-//            for booze in boozeComponents {
-//                if baseSpiritsConvertedIntoStrings.contains(booze.name) {
-//                    strings.append(booze.name)
-//                }
-//            }
-//        }
-//        if let nA = tags.nA {
-//            strings.append(contentsOf: nA.map({$0.name}))
-//        }
-//        if let flavors = tags.flavors {
-//            strings.append(contentsOf: flavors.map({$0.rawValue}))
-//        }
-//        if let styles = tags.styles {
-//            strings.append(contentsOf: styles.map({$0.rawValue}))
-//        }
-//        if let profiles = tags.profiles {
-//            strings.append(contentsOf: profiles.map({$0.rawValue}))
-//        }
-//        return Array(Set(strings))
-//        
-//    }
-//    //                                                                                          MARK: For loops
-//    func returnMatchedBase(_ cocktail: Cocktail) -> String {
-//        var matchedString = ""
-//        if let boozeComponents = cocktail.compiledTags.booze {
-//            for booze in boozeComponents {
-//                for matched in cocktailComponents.filter({ $0.isPreferred }) {
-//                    if matched.name == booze.name && baseSpiritsConvertedIntoStrings.contains(matched.name) {
-//                        matchedString = matched.name
-//                    }
-//                }
-//            }
-//        }
-//        return matchedString
-//    }
 }
+
+
+
+// MARK: VIEW MODEL MIGRATION
+
+extension SearchResultsView {
+    
+    func getFilteredCocktailsSwiftData()  {
+        var startingCocktails: [Cocktail] = []
+        viewModel.isLoading = true
+        viewModel.resetSearchCriteria()
+        if viewModel.returnPreferredBaseSpirits().count > 1 {
+            viewModel.multipleBaseSpiritsSelectedToEnableMenu = true
+        } else {
+            viewModel.multipleBaseSpiritsSelectedToEnableMenu = false
+        }
+       
+
+        /** First, loop over every cocktail and add any cocktails that don't match any unwanted preferences to create the StartingCocktails array. */
+        /// Start with the appropriate set of cocktails for the corresponding mode
+        
+        startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: cocktails)
+        
+//        if viewModel.showWilliamsAndGrahamCocktails {
+//            startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: CocktailListViewModel().justWilliamsAndGrahamCocktails)
+//        }
+        
+        /**loop over the number of preferredCount / 2 and create ResultViewSectionData objects with count and matched numbers filled in but empty cocktail arrays.
+        Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
+        let finalMatchContainers: [ResultViewSectionData] = {
+            var dataShells = [ResultViewSectionData]()
+            if viewModel.enableResultsForMultipleBaseSpirits == true {
+                /** If we're searching for separate base spirits, we need to add more shells. One for each base spirit searched in each match number about 50%. We also need to use a modified preferredCount that counts all spirits as a total of one. */
+                viewModel.preferredCount = viewModel.modifiedPreferredCount()
+                for i in 0...Int(viewModel.preferredCount / 2) {
+                    let numberOfMatches = (viewModel.preferredCount - i)
+                    for spirit in viewModel.returnPreferredBaseSpirits() {
+                        dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
+                    }
+                }
+                return dataShells
+            } else {
+                /**Otherwise search normaly, allowing individual base spirits to add to the total search count.**/
+                viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
+                for i in 0...Int(viewModel.preferredCount / 2) {
+                    let numberOfMatches = (viewModel.preferredCount - i)
+                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: []))
+                }
+                return dataShells
+            }
+        }()
+        /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
+        for cocktail in startingCocktails {
+            
+            /** We use let _ = ... to loop over finalMatchContainers to append cocktails that match preferred components to the right section without creating a new array in the process */
+            let _ = finalMatchContainers.map { resultViewSectionData in
+                
+            /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
+                if viewModel.enableResultsForMultipleBaseSpirits == false {
+                    if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
+                        resultViewSectionData.cocktails.append(cocktail)
+                    }
+                } else {
+                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
+                            resultViewSectionData.cocktails.append(cocktail)
+                        //print("the count match for \(cocktail.cocktailName) is \(countMatchesForMultipleSpirits(for: cocktail))")
+                    }
+                }
+            }
+        }
+        
+        /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
+        viewModel.sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
+         
+        /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
+                i.e.
+            sections = finalMatchContainers.compactMap { resultSectionData in
+            return resultSectionData.cocktails.isEmpty ? nil : resultSectionData } */
+
+        viewModel.isLoading = false
+    }
+    
+    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
+        // compare preferredComponent against current cocktail of loop, then return number of matches.
+        var justBases = [String]()
+        var alreadyMatchedSpec = 0
+        if let booze = cocktail.compiledTags.booze {
+            for booze in booze {
+                if !viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
+                    justBases.append(booze.name)
+                }
+            }
+        }
+
+        let matches = viewModel.cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
+            for spec in justBases {
+                if spec == component.name && alreadyMatchedSpec == 0 {
+                    partialResult += 1
+                    alreadyMatchedSpec += 1
+                }
+            }
+            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
+                    partialResult += 1
+                }
+        })
+        return matches
+    }
+                                                                                        
+    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
+        var strings: [String] = [String]()
+        if let boozeComponents = tags.booze {
+            for booze in boozeComponents {
+                if viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
+                    strings.append(booze.name)
+                }
+            }
+        }
+        if let nA = tags.nA {
+            strings.append(contentsOf: nA.map({$0.name}))
+        }
+        if let flavors = tags.flavors {
+            strings.append(contentsOf: flavors.map({$0.rawValue}))
+        }
+        if let styles = tags.styles {
+            strings.append(contentsOf: styles.map({$0.rawValue}))
+        }
+        if let profiles = tags.profiles {
+            strings.append(contentsOf: profiles.map({$0.rawValue}))
+        }
+        return Array(Set(strings))
+        
+    }
+
+    private func returnMatchedBase(_ cocktail: Cocktail) -> String {
+        var matchedString = ""
+        if let boozeComponents = cocktail.compiledTags.booze {
+            for booze in boozeComponents {
+                for matched in viewModel.cocktailComponents.filter({ $0.isPreferred }) {
+                    if matched.name == booze.name && viewModel.baseSpiritsConvertedIntoStrings.contains(matched.name) {
+                        matchedString = matched.name
+                    }
+                }
+            }
+        }
+        return matchedString
+    }
+    
+    // we had to move this into the view because it calls getFilteredCocktailsSwiftData() which can't be a static var.
+    func removePreference(for component: CocktailComponent) {
+        // When we click a green bubble to remove a preferred tag, we change the data and the UI updates.
+        
+        viewModel.preferredCount -= 1
+        let cocktailComponent = viewModel.cocktailComponents.filter ({ $0.id == component.id })
+        cocktailComponent.first?.isPreferred = false
+        getFilteredCocktailsSwiftData()
+    }
+    
+    // we had to move this into the view because it calls getFilteredCocktailsSwiftData() which can't be a static var.
+    func removeUnwanted(for component: CocktailComponent) {
+        // When we click a red bubble to remove an unwanted tag, we change the data and the UI updates.
+        let cocktailComponent = viewModel.cocktailComponents.filter ({ $0.id == component.id })
+        cocktailComponent.first?.isUnwanted = false
+        getFilteredCocktailsSwiftData()
+    }
+    
+    func convertTagsAndSpecToStrings(for cocktail: Cocktail) -> [String] {
+        var strings: [String] = [String]()
+        strings.append(contentsOf: cocktail.spec.map({$0.ingredient.name}))
+        if let booze = cocktail.compiledTags.booze {
+            strings.append(contentsOf: booze.map({$0.name}))
+        }
+        if let flavors = cocktail.compiledTags.flavors {
+            strings.append(contentsOf: flavors.map({$0.rawValue}))
+        }
+        if let styles = cocktail.compiledTags.styles {
+            strings.append(contentsOf: styles.map({$0.rawValue}))
+        }
+        if let profiles = cocktail.compiledTags.profiles {
+            strings.append(contentsOf: profiles.map({$0.rawValue}))
+        }
+        if let nA = cocktail.compiledTags.nA {
+            strings.append(contentsOf: nA.map({$0.name}))
+        }
+        return Array(Set(strings))
+    }
+    
+    func filterUnwantedCocktails(cocktailComponentArray: [CocktailComponent], cocktails: [Cocktail]) -> [Cocktail] {
+         cocktails.filter { cocktail in
+             cocktailComponentArray.allSatisfy { unwantedComponent in
+                !convertTagsAndSpecToStrings(for: cocktail).contains(unwantedComponent.name)
+            }
+        }
+    }
+    
+    func countMatches(_ currentCount: Int, for preferredComponent: CocktailComponent, in cocktail: Cocktail) -> Int {
+        // compare preferredComponent against current cocktail of loop, then return number of matches.
+        var matches = currentCount
+        if convertTagsAndSpecToStrings(for: cocktail).contains(preferredComponent.name){
+            matches += 1
+        }
+        return matches
+    }
+}
+
 

--- a/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
@@ -74,11 +74,11 @@ struct SearchResultsView: View {
                 Menu("Sort Results") {
                     Button("By number of matches: Apply to a single cocktail.", action: {
                         viewModel.enableResultsForMultipleBaseSpirits = false
-                        gitFilteredCocktailsSwiftData()
+                        getFilteredCocktailsSwiftData()
                     })
                     Button("By Spirit: Separate your results based on the spirit.", action: {
                         viewModel.enableResultsForMultipleBaseSpirits = true
-                        gitFilteredCocktailsSwiftData()
+                        getFilteredCocktailsSwiftData()
                     })
                 }
                 .padding(10)
@@ -86,15 +86,11 @@ struct SearchResultsView: View {
                 .buttonStyle(BlackNWhiteButton())
                 .frame(maxWidth: .infinity, alignment: .center)
             }
-            
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear() {
-            
-            gitFilteredCocktailsSwiftData()
-     
+            getFilteredCocktailsSwiftData()
         }
-        
     }
     
     @ViewBuilder func TagView(_ tag: String, _ color: Color, _ icon: String) -> some View {
@@ -115,217 +111,16 @@ struct SearchResultsView: View {
             Capsule()
                 .fill(color.gradient)
         }
-        
     }
-    // MARK: BEGINNING OF VIEW MODEL MIGRATION ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    func gitFilteredCocktailsSwiftData()  {
-        var startingCocktails: [Cocktail] = []
-        viewModel.isLoading = true
-        viewModel.resetSearchCriteria()
-        if viewModel.returnPreferredBaseSpirits().count > 1 {
-            viewModel.multipleBaseSpiritsSelectedToEnableMenu = true
-        } else {
-            viewModel.multipleBaseSpiritsSelectedToEnableMenu = false
-        }
-       
-
-        /** First, loop over every cocktail and add any cocktails that don't match any unwanted preferences to create the StartingCocktails array. */
-        /// Start with the appropriate set of cocktails for the corresponding mode
-        ///
-        
-        startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: cocktails)
-        
-        
-//        if viewModel.showWilliamsAndGrahamCocktails {
-//            startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: CocktailListViewModel().justWilliamsAndGrahamCocktails)
-//        }
-        
-        /**loop over the number of preferredCount / 2 and create ResultViewSectionData objects with count and matched numbers filled in but empty cocktail arrays.
-        Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
-        let finalMatchContainers: [ResultViewSectionData] = {
-            var dataShells = [ResultViewSectionData]()
-            if viewModel.enableResultsForMultipleBaseSpirits == true {
-                /** If we're searching for separate base spirits, we need to add more shells. One for each base spirit searched in each match number about 50%. We also need to use a modified preferredCount that counts all spirits as a total of one. */
-                viewModel.preferredCount = viewModel.modifiedPreferredCount()
-                for i in 0...Int(viewModel.preferredCount / 2) {
-                    let numberOfMatches = (viewModel.preferredCount - i)
-                    for spirit in viewModel.returnPreferredBaseSpirits() {
-                        dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
-                    }
-                }
-                return dataShells
-            } else {
-                /**Otherwise search normaly, allowing individual base spirits to add to the total search count.**/
-                viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
-                for i in 0...Int(viewModel.preferredCount / 2) {
-                    let numberOfMatches = (viewModel.preferredCount - i)
-                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: []))
-                }
-                return dataShells
-            }
-        }()
-        /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
-        for cocktail in startingCocktails {
-            
-            /** We use let _ = ... to loop over finalMatchContainers to append cocktails that match preferred components to the right section without creating a new array in the process */
-            let _ = finalMatchContainers.map { resultViewSectionData in
-                
-            /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
-                if viewModel.enableResultsForMultipleBaseSpirits == false {
-                    if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
-                        resultViewSectionData.cocktails.append(cocktail)
-                    }
-                } else {
-                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
-                            resultViewSectionData.cocktails.append(cocktail)
-                        //print("the count match for \(cocktail.cocktailName) is \(countMatchesForMultipleSpirits(for: cocktail))")
-                    }
-                }
-            }
-        }
-        
-        /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
-        viewModel.sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
-         
-        /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
-                i.e.
-            sections = finalMatchContainers.compactMap { resultSectionData in
-            return resultSectionData.cocktails.isEmpty ? nil : resultSectionData } */
-
-        viewModel.isLoading = false
-        print("The cocktail count is \(cocktails.count)")
-       
-        
-    }
-    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
-        // compare preferredComponent against current cocktail of loop, then return number of matches.
-        var justBases = [String]()
-        var alreadyMatchedSpec = 0
-        if let booze = cocktail.compiledTags.booze {
-            for booze in booze {
-                if !viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-                    justBases.append(booze.name)
-                }
-            }
-        }
-        // FUNCTION NEED ACCESS TO VIEW MODEL
-        let matches = viewModel.cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
-            for spec in justBases {
-                if spec == component.name && alreadyMatchedSpec == 0 {
-                    partialResult += 1
-                    alreadyMatchedSpec += 1
-                }
-            }
-            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
-                    partialResult += 1
-                }
-        })
-        return matches
-    }
-                                                                                        
-    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
-        var strings: [String] = [String]()
-        if let boozeComponents = tags.booze {
-            for booze in boozeComponents {
-                if viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-                    strings.append(booze.name)
-                }
-            }
-        }
-        if let nA = tags.nA {
-            strings.append(contentsOf: nA.map({$0.name}))
-        }
-        if let flavors = tags.flavors {
-            strings.append(contentsOf: flavors.map({$0.rawValue}))
-        }
-        if let styles = tags.styles {
-            strings.append(contentsOf: styles.map({$0.rawValue}))
-        }
-        if let profiles = tags.profiles {
-            strings.append(contentsOf: profiles.map({$0.rawValue}))
-        }
-        return Array(Set(strings))
-        
-    }
-
-    private func returnMatchedBase(_ cocktail: Cocktail) -> String {
-        var matchedString = ""
-        if let boozeComponents = cocktail.compiledTags.booze {
-            for booze in boozeComponents {
-                for matched in viewModel.cocktailComponents.filter({ $0.isPreferred }) {
-                    if matched.name == booze.name && viewModel.baseSpiritsConvertedIntoStrings.contains(matched.name) {
-                        matchedString = matched.name
-                    }
-                }
-            }
-        }
-        return matchedString
-    }
-    // we had to move this into the view because it calls gitFilteredCocktailsSwiftData() which can't be a static var.
-    func removePreference(for component: CocktailComponent) {
-        // When we click a green bubble to remove a preferred tag, we change the data and the UI updates.
-        
-        viewModel.preferredCount -= 1
-        let cocktailComponent = viewModel.cocktailComponents.filter ({ $0.id == component.id })
-        cocktailComponent.first?.isPreferred = false
-        gitFilteredCocktailsSwiftData()
-    }
-    // we had to move this into the view because it calls gitFilteredCocktailsSwiftData() which can't be a static var.
-    func removeUnwanted(for component: CocktailComponent) {
-        // When we click a red bubble to remove an unwanted tag, we change the data and the UI updates.
-        let cocktailComponent = viewModel.cocktailComponents.filter ({ $0.id == component.id })
-        cocktailComponent.first?.isUnwanted = false
-        gitFilteredCocktailsSwiftData()
-    }
-    
-    func convertTagsAndSpecToStrings(for cocktail: Cocktail) -> [String] {
-        var strings: [String] = [String]()
-        strings.append(contentsOf: cocktail.spec.map({$0.ingredient.name}))
-        if let booze = cocktail.compiledTags.booze {
-            strings.append(contentsOf: booze.map({$0.name}))
-        }
-        if let flavors = cocktail.compiledTags.flavors {
-            strings.append(contentsOf: flavors.map({$0.rawValue}))
-        }
-        if let styles = cocktail.compiledTags.styles {
-            strings.append(contentsOf: styles.map({$0.rawValue}))
-        }
-        if let profiles = cocktail.compiledTags.profiles {
-            strings.append(contentsOf: profiles.map({$0.rawValue}))
-        }
-        if let nA = cocktail.compiledTags.nA {
-            strings.append(contentsOf: nA.map({$0.name}))
-        }
-        return Array(Set(strings))
-    }
-    func filterUnwantedCocktails(cocktailComponentArray: [CocktailComponent], cocktails: [Cocktail]) -> [Cocktail] {
-         cocktails.filter { cocktail in
-             cocktailComponentArray.allSatisfy { unwantedComponent in
-                !convertTagsAndSpecToStrings(for: cocktail).contains(unwantedComponent.name)
-            }
-        }
-    }
-    
-    func countMatches(_ currentCount: Int, for preferredComponent: CocktailComponent, in cocktail: Cocktail) -> Int {
-        // compare preferredComponent against current cocktail of loop, then return number of matches.
-        var matches = currentCount
-        if convertTagsAndSpecToStrings(for: cocktail).contains(preferredComponent.name){
-            matches += 1
-        }
-        return matches
-    }
-    // MARK: END OF VIEW MODEL MIGRATION ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 }
 
 struct SearchedCocktailTitleHeader: View {
     
     var searched: Int
     var matched: Int
-    
-    
+
     var body: some View {
         HStack {
-            
             ForEach(0..<matched, id: \.self) { match in
                 Image(systemName: "circle.fill")
                     .foregroundStyle(Color.green)
@@ -334,36 +129,6 @@ struct SearchedCocktailTitleHeader: View {
             if matched - searched < 0 {
                 ForEach(0..<(searched - matched), id: \.self) { nonMatch in
                     Image(systemName: "circle.fill")
-                    
-                }
-            }
-            
-            Spacer()
-            
-            Text("^[\(matched)/\(searched) matches](inflect: true)")
-        }
-    }
-}
-struct SearchedCocktailTitleHeaderForMultipleSpirits: View {
-    
-    var searched: Int
-    var matched: Int
-    var baseSpirit: String
-    
-    
-    var body: some View {
-        HStack {
-            Text(baseSpirit)
-                .font(.headline).bold()
-            ForEach(0..<matched, id: \.self) { match in
-                Image(systemName: "circle.fill")
-                    .foregroundStyle(Color.green)
-            }
-            
-            if matched - searched < 0 {
-                ForEach(0..<(searched - matched), id: \.self) { nonMatch in
-                    Image(systemName: "circle.fill")
-                    
                 }
             }
             
@@ -374,6 +139,35 @@ struct SearchedCocktailTitleHeaderForMultipleSpirits: View {
     }
 }
 
+struct SearchedCocktailTitleHeaderForMultipleSpirits: View {
+    
+    var searched: Int
+    var matched: Int
+    var baseSpirit: String
+    
+    var body: some View {
+        HStack {
+            Text(baseSpirit)
+                .font(.headline).bold()
+            
+            ForEach(0..<matched, id: \.self) { match in
+                Image(systemName: "circle.fill")
+                    .foregroundStyle(Color.green)
+            }
+            
+            if matched - searched < 0 {
+                ForEach(0..<(searched - matched), id: \.self) { nonMatch in
+                    Image(systemName: "circle.fill")
+                    
+                }
+            }
+            
+            Spacer()
+            
+            Text("^[\(matched)/\(searched) matches](inflect: true)")
+        }
+    }
+}
 
 struct SearchedCocktailCell: View {
     
@@ -391,5 +185,4 @@ struct SearchedCocktailCell: View {
     let preview = PreviewContainer([Cocktail.self], isStoredInMemoryOnly: true)
     return SearchResultsView(viewModel: SearchCriteriaViewModel())
         .modelContainer(preview.container)
-       
 }


### PR DESCRIPTION
Just a cleanup really, for pieces of work like this it's better to make them an extension. In this case I think it just makes more sense for this extension to live in the viewModel. Kind of a happy middle ground.

Don't worry about deleting the commented out old code from the viewmodel - we can access that through git anytime.

My proposed next step is to improve our search logic. We seem to be one step behind what is being typed, example (ingredients containing "me" are shown, not "mez" as expected:
![image](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/96077863/c749f538-b8cd-4ce9-b88a-3e82e2478faa)

Also, we'll want to make it so that any typed in search items that exactly match go to the top. 
An example of how it's working now ("gin" should be the first result):

![image](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/96077863/12e83e84-b2d1-4c48-a9eb-5874cb4d4e6d)

Once that's done, I'd like you to see if you can make the add ingredient and add garnish views push onto the stack to match the behavior of other pickers like the "select glassware" and "select ice". The menu for garnish, and modal view for add ingredient work well - but ideally they would slide in from the right to match the others. You won't be able to exactly replicate how this is done for glassware and ice, so this will take some figuring out. I believe in you though!

Amazing work so far

