### PR TITLE
Unmatched results filtering

### DIFF
--- a/MetaCocktailsSwiftData/Model/Cocktail.swift
+++ b/MetaCocktailsSwiftData/Model/Cocktail.swift
@@ -33,11 +33,10 @@ class Cocktail: Equatable, Hashable {
     var collection: CocktailCollection?
     var collectionName: String
     var titleCocktail: Bool?
-    var nonmatchPreferences: [String]?
   
     
     
-    init(id: UUID = UUID(), cocktailName: String, imageAsset: CocktailImage? = nil, glasswareType: Glassware, garnish: [Garnish]? = nil, ice: Ice? = nil, author: Author? = nil, spec: [CocktailIngredient], buildOrder: Build? = nil, tags: Tags, variation: Variation? = nil, collection: CocktailCollection? = nil, titleCocktail: Bool = false, nonmatchPreferences: [String]? = nil) {
+    init(id: UUID = UUID(), cocktailName: String, imageAsset: CocktailImage? = nil, glasswareType: Glassware, garnish: [Garnish]? = nil, ice: Ice? = nil, author: Author? = nil, spec: [CocktailIngredient], buildOrder: Build? = nil, tags: Tags, variation: Variation? = nil, collection: CocktailCollection? = nil, titleCocktail: Bool = false) {
         self.id = id
         self.cocktailName = cocktailName
         self.imageAsset = imageAsset
@@ -59,7 +58,6 @@ class Cocktail: Equatable, Hashable {
             return name
         }()
         self.titleCocktail = titleCocktail
-        self.nonmatchPreferences = nonmatchPreferences
         self.compiledTags = {
             // when we initialize each cocktail we immediately make a stored property of it's combined cocktail + ingredient tags
             var newCompiledTags = Tags()

--- a/MetaCocktailsSwiftData/Model/Cocktail.swift
+++ b/MetaCocktailsSwiftData/Model/Cocktail.swift
@@ -33,10 +33,11 @@ class Cocktail: Equatable, Hashable {
     var collection: CocktailCollection?
     var collectionName: String
     var titleCocktail: Bool?
+    var nonmatchPreferences: [String]?
   
     
     
-    init(id: UUID = UUID(), cocktailName: String, imageAsset: CocktailImage? = nil, glasswareType: Glassware, garnish: [Garnish]? = nil, ice: Ice? = nil, author: Author? = nil, spec: [CocktailIngredient], buildOrder: Build? = nil, tags: Tags, variation: Variation? = nil, collection: CocktailCollection? = nil, titleCocktail: Bool = false) {
+    init(id: UUID = UUID(), cocktailName: String, imageAsset: CocktailImage? = nil, glasswareType: Glassware, garnish: [Garnish]? = nil, ice: Ice? = nil, author: Author? = nil, spec: [CocktailIngredient], buildOrder: Build? = nil, tags: Tags, variation: Variation? = nil, collection: CocktailCollection? = nil, titleCocktail: Bool = false, nonmatchPreferences: [String]? = nil) {
         self.id = id
         self.cocktailName = cocktailName
         self.imageAsset = imageAsset
@@ -58,6 +59,7 @@ class Cocktail: Equatable, Hashable {
             return name
         }()
         self.titleCocktail = titleCocktail
+        self.nonmatchPreferences = nonmatchPreferences
         self.compiledTags = {
             // when we initialize each cocktail we immediately make a stored property of it's combined cocktail + ingredient tags
             var newCompiledTags = Tags()

--- a/MetaCocktailsSwiftData/Model/Components/Ingredients/Alcohol.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredients/Alcohol.swift
@@ -947,51 +947,54 @@ enum Bitters: String, Codable, CaseIterable {
     case orangeBitters         = "Regans Orange Bitters"
     case peychauds             = "Peychaud's Bitters"
     case pimentoBitters        = "Pimento Bitters (Dale Degroff's)"
+    case bitters               = "Bitters"
     
     var tags: Tags {
         switch self {
         case .blackWalnut:
-            Tags(flavors: [.walnut], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.walnut], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .orangeBitters:
-            Tags(flavors: [.orange], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.orange], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .angosturaBitters:
-            Tags(flavors: [.bakingSpices], booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters))])
+            Tags(flavors: [.bakingSpices], booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters)),Booze(.bitters(.bitters))])
         case .peychauds:
-            Tags(flavors: [.tarragon, .cherry], booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters))])
+            Tags(booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters)), Booze(.bitters(.bitters))])
         case .pimentoBitters:
-            Tags(flavors: [.pimento], booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters))])
+            Tags(flavors: [.pimento], booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters)),Booze(.bitters(.bitters))])
         case .hellfireBitters:
-            Tags(profiles: [.spicy], booze: [Booze(.bitters(self))])
+            Tags(profiles: [.spicy], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .celeryBitters:
-            Tags(flavors: [.celery], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.celery], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .chocolateMole:
-            Tags(flavors: [.chocolate, .molé], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.chocolate, .molé], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .aromaticBitters:
-            Tags(booze: [Booze(.bitters(self))])
+            Tags(booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .appleBitters:
-            Tags(flavors: [.apple], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.apple], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .hoppedGrapefruit:
-            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .lemonBitters:
-            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .tikiBitters:
-            Tags(flavors: [.cinnamon, .bakingSpices], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.cinnamon, .bakingSpices], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .grapefruitBitters:
-            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.grapefruit], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .bolivarBitters:
-            Tags(booze: [Booze(.bitters(self))])
+            Tags(booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .blackstrapBitters:
-            Tags(flavors: [.molasses], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.molasses], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .bittercubeJamaican1:
-            Tags(booze: [Booze(.bitters(self))])
+            Tags(booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .bitterTruthJTDecanter:
-            Tags(booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters))])
+            Tags(booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters)),Booze(.bitters(.bitters))])
         case .bittermansChocolate:
-            Tags(flavors: [.chocolate], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.chocolate], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         case .aPPBitters:
-            Tags(booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters))])
+            Tags(booze: [Booze(.bitters(self)), Booze(.bitters(.aromaticBitters)),Booze(.bitters(.bitters))])
         case .houseOrangeBitters:
-            Tags(flavors: [.orange], booze: [Booze(.bitters(self))])
+            Tags(flavors: [.orange], booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
+        case .bitters:
+            Tags(booze: [Booze(.bitters(self)),Booze(.bitters(.bitters))])
         }
     }
     

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
@@ -37,7 +37,7 @@ struct CocktailResultList: View {
                                             
                                             FilterMatchesMenuView(viewModel: viewModel, resultViewSectionData: result, nonmatchSearchPreference: $nonmatchSearchPreference)
                                             
-                                            if result.filterPreference == "none" {
+                                            if nonmatchSearchPreference == "none" {
                                                 
                                                 PartialMatchWithNoPreferenceView(viewModel: viewModel, resultViewSectionData: result)
                                                 
@@ -119,13 +119,11 @@ struct FilterMatchesMenuView: View {
             ForEach(viewModel.selectedPreferredIngredients(), id: \.id) { preference in
                 
                 Button("- \(preference.name)") {
-                    resultViewSectionData.filterPreference = preference.name
                     nonmatchSearchPreference = preference.name
                 }
                 .foregroundStyle(.brandPrimaryRed)
             }
             Button {
-                resultViewSectionData.filterPreference = "none"
                 nonmatchSearchPreference = "none"
             } label: {
                 Text("Show all")

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
@@ -43,32 +43,36 @@ struct CocktailResultList: View {
                                                 
                                             } else {
                                                 
-                                                ForEach(result.cocktails.filter({ $0.nonmatchPreferences!.contains(result.filterPreference)}), id: \.self.id) { cocktail in
+                                                ForEach(result.cocktails.filter({$0.missingIngredients.contains(nonmatchSearchPreference)}), id: \.self.id) { cocktail in
                                                     NavigationLink {
                                                         
-                                                        RecipeView(viewModel: RecipeViewModel(cocktail: cocktail))
+                                                        RecipeView(viewModel: RecipeViewModel(cocktail: cocktail.cocktail))
                                                         
                                                             .navigationBarBackButtonHidden(true)
                                                     } label: {
                                                         VStack {
                                                             HStack{
-                                                                Text(cocktail.cocktailName)
+                                                                Text(cocktail.cocktail.cocktailName)
                                                                 Spacer()
                                                             }
                                                             HStack{
-                                                                if let missingPreferences = cocktail.nonmatchPreferences {
-                                                                    ForEach(missingPreferences, id: \.self) { nonMatch in
-                                                                        
-                                                                        Text("-\(nonMatch) ")
-                                                                            .foregroundStyle(.brandPrimaryRed)
-                                                                            .font(.caption)
-                                                                    }
+                                                                ForEach(cocktail.missingIngredients, id: \.self) { nonMatch in
+                                                                    Text("-\(nonMatch) ")
+                                                                        .foregroundStyle(.brandPrimaryRed)
+                                                                        .font(.caption)
                                                                 }
                                                                 Spacer()
                                                             }
                                                         }
                                                     }
                                                 }
+                                                
+                                                
+                                                
+                                                
+                                                
+//                                                ForEach(result.cocktails.filter({ $0.nonmatchPreferences!.contains(result.filterPreference)}), id: \.self.id) { cocktail in
+                                                    
                                             }
                                         }
                                     }
@@ -137,11 +141,11 @@ struct TotalMatchView: View {
     var body: some View {
         ForEach(resultViewSectionData.cocktails, id: \.self.id) { cocktail in
             NavigationLink {
-                RecipeView(viewModel: RecipeViewModel(cocktail: cocktail))
+                RecipeView(viewModel: RecipeViewModel(cocktail: cocktail.cocktail))
                     .navigationBarBackButtonHidden(true)
             } label: {
                 HStack {
-                    Text(cocktail.cocktailName)
+                    Text(cocktail.cocktail.cocktailName)
                 }
             }
         }
@@ -156,22 +160,19 @@ struct PartialMatchWithNoPreferenceView: View {
     var body: some View {
         ForEach(resultViewSectionData.cocktails, id: \.self.id) { cocktail in
             NavigationLink {
-                RecipeView(viewModel: RecipeViewModel(cocktail: cocktail))
+                RecipeView(viewModel: RecipeViewModel(cocktail: cocktail.cocktail))
                     .navigationBarBackButtonHidden(true)
             } label: {
                 VStack {
                     HStack{
-                        Text(cocktail.cocktailName)
+                        Text(cocktail.cocktail.cocktailName)
                         Spacer()
                     }
                     HStack{
-                        if let missingPreferences = cocktail.nonmatchPreferences {
-                            ForEach(missingPreferences, id: \.self) { nonMatch in
-                                
-                                Text("-\(nonMatch) ")
-                                    .foregroundStyle(.brandPrimaryRed)
-                                    .font(.caption)
-                            }
+                        ForEach(cocktail.missingIngredients, id: \.self) { nonMatch in
+                            Text("-\(nonMatch) ")
+                                .foregroundStyle(.brandPrimaryRed)
+                                .font(.caption)
                         }
                         Spacer()
                     }

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/CocktailResultListView.swift
@@ -66,13 +66,6 @@ struct CocktailResultList: View {
                                                         }
                                                     }
                                                 }
-                                                
-                                                
-                                                
-                                                
-                                                
-//                                                ForEach(result.cocktails.filter({ $0.nonmatchPreferences!.contains(result.filterPreference)}), id: \.self.id) { cocktail in
-                                                    
                                             }
                                         }
                                     }

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
@@ -12,10 +12,11 @@ class ResultViewSectionData {
     let count: Int
     let matched: Int
     var baseSpirit: String
-    var cocktails: [Cocktail]
+    var cocktails: [CocktailsAndTheirMissingIngredients]
     var filterPreference: String
+    //var missingIngredientCocktails: [MissingIngredientSectionData]
     
-    init(count: Int, matched: Int, baseSpirit: String, cocktails: [Cocktail], filterPreference: String = "none") {
+    init(count: Int, matched: Int, baseSpirit: String, cocktails: [CocktailsAndTheirMissingIngredients], filterPreference: String) {
         self.count = count
         self.matched = matched
         self.baseSpirit = baseSpirit
@@ -24,3 +25,21 @@ class ResultViewSectionData {
     }
 }
 
+class CocktailsAndTheirMissingIngredients: Equatable, Hashable {
+    static func == (lhs: CocktailsAndTheirMissingIngredients, rhs: CocktailsAndTheirMissingIngredients) -> Bool {
+        return lhs.missingIngredients == rhs.missingIngredients
+    }
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(missingIngredients)
+    }
+    
+    let id = UUID()
+    var missingIngredients: [String]
+    var cocktail: Cocktail
+    
+    init(missingIngredients: [String], cocktail: Cocktail) {
+        self.missingIngredients = missingIngredients
+        self.cocktail = cocktail
+    }
+    
+}

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
@@ -8,38 +8,25 @@
 import SwiftUI
 
 class ResultViewSectionData {
+    
     let id = UUID()
     let count: Int
     let matched: Int
-    var baseSpirit: String
-    var cocktails: [CocktailsAndTheirMissingIngredients]
-    var filterPreference: String
-    //var missingIngredientCocktails: [MissingIngredientSectionData]
+    var cocktails: [CocktailsAndMissingIngredients]
     
-    init(count: Int, matched: Int, baseSpirit: String, cocktails: [CocktailsAndTheirMissingIngredients], filterPreference: String) {
+    init(count: Int, matched: Int, cocktails: [CocktailsAndMissingIngredients]) {
         self.count = count
         self.matched = matched
-        self.baseSpirit = baseSpirit
         self.cocktails = cocktails
-        self.filterPreference = filterPreference
     }
 }
 
-class CocktailsAndTheirMissingIngredients: Equatable, Hashable {
-    static func == (lhs: CocktailsAndTheirMissingIngredients, rhs: CocktailsAndTheirMissingIngredients) -> Bool {
-        return lhs.missingIngredients == rhs.missingIngredients
-    }
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(missingIngredients)
-    }
+
+struct CocktailsAndMissingIngredients {
     
     let id = UUID()
     var missingIngredients: [String]
     var cocktail: Cocktail
-    
-    init(missingIngredients: [String], cocktail: Cocktail) {
-        self.missingIngredients = missingIngredients
-        self.cocktail = cocktail
-    }
+
     
 }

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
@@ -13,12 +13,14 @@ class ResultViewSectionData {
     let matched: Int
     var baseSpirit: String
     var cocktails: [Cocktail]
+    var filterPreference: String
     
-    init(count: Int, matched: Int, baseSpirit: String, cocktails: [Cocktail]) {
+    init(count: Int, matched: Int, baseSpirit: String, cocktails: [Cocktail], filterPreference: String = "none") {
         self.count = count
         self.matched = matched
         self.baseSpirit = baseSpirit
         self.cocktails = cocktails
+        self.filterPreference = filterPreference
     }
 }
 

--- a/MetaCocktailsSwiftData/Views/Search View/BasicSearchView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/BasicSearchView.swift
@@ -33,12 +33,6 @@ struct BasicSearchView: View {
                                 .padding(EdgeInsets(top: 0, leading: 12, bottom: -7, trailing: 0))
                             Spacer()
                             Menu("", systemImage: "gearshape") {
-                                Button("Filter All Cocktails") {
-                                    viewModel.showWilliamsAndGrahamCocktails = false
-                                }
-                                Button("Filter Williams and Graham Cocktails") {
-                                    viewModel.showWilliamsAndGrahamCocktails = true
-                                }
                                 Button("Search by flavor.", action: {
                                     isShowingFlavors = true
                                 })

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -142,10 +142,7 @@ final class SearchCriteriaViewModel: ObservableObject {
         return preferredIngredients
     }
     func shouldShowSearchButton() -> Bool {
-        if cocktailComponents.filter({ $0.isPreferred }).count > 0 {
-            return true
-        }
-        return false 
+        cocktailComponents.filter({ $0.isPreferred }).count > 0
     }
     func selectedUnwantedIngredients() -> [CocktailComponent] {
         self.cocktailComponents.filter({ $0.isUnwanted })
@@ -204,7 +201,6 @@ final class SearchCriteriaViewModel: ObservableObject {
 extension SearchResultsView {
     
     func getFilteredCocktailsSwiftData()  {
-        print("This got fired")
         var startingCocktails: [Cocktail] = []
         viewModel.isLoading = true
         viewModel.resetSearchCriteria()

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -190,43 +190,24 @@ extension SearchResultsView {
         } else {
             viewModel.multipleBaseSpiritsSelectedToEnableMenu = false
         }
-       
-
         /** First, loop over every cocktail and add any cocktails that don't match any unwanted preferences to create the StartingCocktails array. */
         /// Start with the appropriate set of cocktails for the corresponding mode
         
         startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: cocktails)
-        
-//        if viewModel.showWilliamsAndGrahamCocktails {
-//            startingCocktails = filterUnwantedCocktails(cocktailComponentArray: viewModel.selectedUnwantedIngredients(), cocktails: CocktailListViewModel().justWilliamsAndGrahamCocktails)
-//        }
+
         
         /**loop over the number of preferredCount / 2 and create ResultViewSectionData objects with count and matched numbers filled in but empty cocktail arrays.
-        Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
+         Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
         let finalMatchContainers: [ResultViewSectionData] = {
             var dataShells = [ResultViewSectionData]()
-//            if viewModel.enableResultsForMultipleBaseSpirits == true {
-                /** If we're searching for separate base spirits, we need to add more shells. One for each base spirit searched in each match number about 50%. We also need to use a modified preferredCount that counts all spirits as a total of one. */
-//                viewModel.preferredCount = viewModel.modifiedPreferredCount()
-//                for i in 0...Int(viewModel.preferredCount / 2) {
-//                    let numberOfMatches = (viewModel.preferredCount - i)
-//                    for spirit in viewModel.returnPreferredBaseSpirits() {
-//                        dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
-//                    }
-//                }
-//                return dataShells
-//            } else {
-                /**Otherwise search normaly, allowing individual base spirits to add to the total search count.**/
-                viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
-                for i in 0...Int(viewModel.preferredCount / 2) {
-                    let numberOfMatches = (viewModel.preferredCount - i)
-                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, cocktails: []))
-                }
-                return dataShells
-//            }
+            viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
+            for i in 0...Int(viewModel.preferredCount / 2) {
+                let numberOfMatches = (viewModel.preferredCount - i)
+                dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, cocktails: []))
+            }
+            return dataShells
+            
         }()
-     
-        
         /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
         for cocktail in startingCocktails {
             
@@ -234,27 +215,16 @@ extension SearchResultsView {
             let _ = finalMatchContainers.map { resultViewSectionData in
                 
                 /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
-//                if viewModel.enableResultsForMultipleBaseSpirits == false {
-                    if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
-                   
-                        resultViewSectionData.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findUnmatchedComponents(for: cocktail), cocktail: cocktail))
-                        
-                    }
-                
-//                } else {
-//                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
-//                        cocktail.nonmatchPreferences = findUnmatchedComponents(for: cocktail)
-//                        resultViewSectionData.cocktails.append(cocktail)
-//                    }
-//                }
+                //                if viewModel.enableResultsForMultipleBaseSpirits == false {
+                if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
+                    
+                    resultViewSectionData.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findUnmatchedComponents(for: cocktail), cocktail: cocktail))
+                    
+                }
             }
-     
         }
-        
-        
         /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
         viewModel.sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
-        
         
         /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
          i.e.
@@ -263,71 +233,7 @@ extension SearchResultsView {
         print("The cocktail count is \(cocktails.count)")
         viewModel.isLoading = false
     }
-    
-//    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
-//        // compare preferredComponent against current cocktail of loop, then return number of matches.
-//        var justBases = [String]()
-//        var alreadyMatchedSpec = 0
-//        if let booze = cocktail.compiledTags.booze {
-//            for booze in booze {
-//                if !viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-//                    justBases.append(booze.name)
-//                }
-//            }
-//        }
-//
-//        let matches = viewModel.cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
-//            for spec in justBases {
-//                if spec == component.name && alreadyMatchedSpec == 0 {
-//                    partialResult += 1
-//                    alreadyMatchedSpec += 1
-//                }
-//            }
-//            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
-//                    partialResult += 1
-//                }
-//        })
-//        return matches
-//    }
-                                                                                        
-//    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
-//        var strings: [String] = [String]()
-//        if let boozeComponents = tags.booze {
-//            for booze in boozeComponents {
-//                if viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-//                    strings.append(booze.name)
-//                }
-//            }
-//        }
-//        if let nA = tags.nA {
-//            strings.append(contentsOf: nA.map({$0.name}))
-//        }
-//        if let flavors = tags.flavors {
-//            strings.append(contentsOf: flavors.map({$0.rawValue}))
-//        }
-//        if let styles = tags.styles {
-//            strings.append(contentsOf: styles.map({$0.rawValue}))
-//        }
-//        if let profiles = tags.profiles {
-//            strings.append(contentsOf: profiles.map({$0.rawValue}))
-//        }
-//        return Array(Set(strings))
-//        
-//    }
 
-//    private func returnMatchedBase(_ cocktail: Cocktail) -> String {
-//        var matchedString = ""
-//        if let boozeComponents = cocktail.compiledTags.booze {
-//            for booze in boozeComponents {
-//                for matched in viewModel.cocktailComponents.filter({ $0.isPreferred }) {
-//                    if matched.name == booze.name && viewModel.baseSpiritsConvertedIntoStrings.contains(matched.name) {
-//                        matchedString = matched.name
-//                    }
-//                }
-//            }
-//        }
-//        return matchedString
-//    }
     
     // we had to move this into the view because it calls getFilteredCocktailsSwiftData() which can't be a static var.
     func removePreference(for component: CocktailComponent) {

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -141,6 +141,12 @@ final class SearchCriteriaViewModel: ObservableObject {
         preferredIngredients = self.cocktailComponents.filter({ $0.isPreferred })
         return preferredIngredients
     }
+    func shouldShowSearchButton() -> Bool {
+        if cocktailComponents.filter({ $0.isPreferred }).count > 0 {
+            return true
+        }
+        return false 
+    }
     func selectedUnwantedIngredients() -> [CocktailComponent] {
         self.cocktailComponents.filter({ $0.isUnwanted })
     }

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -220,7 +220,7 @@ extension SearchResultsView {
                 viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
                 for i in 0...Int(viewModel.preferredCount / 2) {
                     let numberOfMatches = (viewModel.preferredCount - i)
-                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: [], filterPreference: "none"))
+                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, cocktails: []))
                 }
                 return dataShells
 //            }
@@ -237,7 +237,7 @@ extension SearchResultsView {
 //                if viewModel.enableResultsForMultipleBaseSpirits == false {
                     if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
                    
-                        resultViewSectionData.cocktails.append(CocktailsAndTheirMissingIngredients(missingIngredients: findUnmatchedComponents(for: cocktail), cocktail: cocktail))
+                        resultViewSectionData.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findUnmatchedComponents(for: cocktail), cocktail: cocktail))
                         
                     }
                 

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -220,11 +220,13 @@ extension SearchResultsView {
                 viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
                 for i in 0...Int(viewModel.preferredCount / 2) {
                     let numberOfMatches = (viewModel.preferredCount - i)
-                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: []))
+                    dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: [], filterPreference: "none"))
                 }
                 return dataShells
 //            }
         }()
+     
+        
         /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
         for cocktail in startingCocktails {
             
@@ -234,9 +236,11 @@ extension SearchResultsView {
                 /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
 //                if viewModel.enableResultsForMultipleBaseSpirits == false {
                     if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
-                        cocktail.nonmatchPreferences = findUnmatchedComponents(for: cocktail)
-                        resultViewSectionData.cocktails.append(cocktail)
+                   
+                        resultViewSectionData.cocktails.append(CocktailsAndTheirMissingIngredients(missingIngredients: findUnmatchedComponents(for: cocktail), cocktail: cocktail))
+                        
                     }
+                
 //                } else {
 //                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
 //                        cocktail.nonmatchPreferences = findUnmatchedComponents(for: cocktail)
@@ -244,10 +248,13 @@ extension SearchResultsView {
 //                    }
 //                }
             }
+     
         }
+        
         
         /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
         viewModel.sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
+        
         
         /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
          i.e.
@@ -379,14 +386,8 @@ extension SearchResultsView {
     }
     
     func findUnmatchedComponents(for cocktail: Cocktail ) -> [String] {
-        var componentArray = [String]()
-        for preferedComponent in viewModel.selectedPreferredIngredients() {
-            if !convertTagsAndSpecToStrings(for: cocktail).contains(preferedComponent.name) {
-                componentArray.append(preferedComponent.name)
-            }
-        }
-        return componentArray
-    }
+        
+        return viewModel.selectedPreferredIngredients().map({ $0.name }).filter({ !convertTagsAndSpecToStrings(for: cocktail).contains($0) })
     
-   
+    }
 }

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -135,7 +135,9 @@ final class SearchCriteriaViewModel: ObservableObject {
         self.objectWillChange.send()
     }
     func selectedPreferredIngredients() -> [CocktailComponent] {
-        self.cocktailComponents.filter({ $0.isPreferred })
+        if preferredIngredients.count != 0 { return preferredIngredients }
+        preferredIngredients = self.cocktailComponents.filter({ $0.isPreferred })
+        return preferredIngredients
     }
     func selectedUnwantedIngredients() -> [CocktailComponent] {
         self.cocktailComponents.filter({ $0.isUnwanted })
@@ -147,6 +149,7 @@ final class SearchCriteriaViewModel: ObservableObject {
         cocktailComponents.remove(atOffsets: offsets)
     }
     func resetSearchCriteria() {
+        preferredIngredients.removeAll()
         preferredCount = 0
         sections.removeAll()
     }

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -72,7 +72,7 @@ final class SearchCriteriaViewModel: ObservableObject {
     var searchText: String = ""
     var preferredCount = 0
     var sections = [ResultViewSectionData]()
-    var enableResultsForMultipleBaseSpirits = false
+    //var enableResultsForMultipleBaseSpirits = false
     var isLoading = true
     var multipleBaseSpiritsSelectedToEnableMenu: Bool = false
     var isShowingSearchButton: Bool = false
@@ -205,17 +205,17 @@ extension SearchResultsView {
         Let's say the preferred count is 5. make one object for 5 matches with the count being 5 and the matched being 5 but and empty cocktail array, one object for 4 matches with the count being 5 and the matched being 4 but and empty cocktail array. Finally, an object for 3 matches with the count being 5 but the matched being 3. No more objects will be made for 2 or 1 because those are less than a 50% match. This means we have the possibility for 3 total sections in the returned ResultViewSectionData. */
         let finalMatchContainers: [ResultViewSectionData] = {
             var dataShells = [ResultViewSectionData]()
-            if viewModel.enableResultsForMultipleBaseSpirits == true {
+//            if viewModel.enableResultsForMultipleBaseSpirits == true {
                 /** If we're searching for separate base spirits, we need to add more shells. One for each base spirit searched in each match number about 50%. We also need to use a modified preferredCount that counts all spirits as a total of one. */
-                viewModel.preferredCount = viewModel.modifiedPreferredCount()
-                for i in 0...Int(viewModel.preferredCount / 2) {
-                    let numberOfMatches = (viewModel.preferredCount - i)
-                    for spirit in viewModel.returnPreferredBaseSpirits() {
-                        dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
-                    }
-                }
-                return dataShells
-            } else {
+//                viewModel.preferredCount = viewModel.modifiedPreferredCount()
+//                for i in 0...Int(viewModel.preferredCount / 2) {
+//                    let numberOfMatches = (viewModel.preferredCount - i)
+//                    for spirit in viewModel.returnPreferredBaseSpirits() {
+//                        dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: spirit, cocktails: []))
+//                    }
+//                }
+//                return dataShells
+//            } else {
                 /**Otherwise search normaly, allowing individual base spirits to add to the total search count.**/
                 viewModel.preferredCount = viewModel.selectedPreferredIngredients().count
                 for i in 0...Int(viewModel.preferredCount / 2) {
@@ -223,7 +223,7 @@ extension SearchResultsView {
                     dataShells.append(ResultViewSectionData(count: viewModel.preferredCount, matched: numberOfMatches, baseSpirit: "N/A", cocktails: []))
                 }
                 return dataShells
-            }
+//            }
         }()
         /**Then, loop over every cocktail in the startingCocktailsArray and pull out the cocktails that match with > 50% of the ingredients in the preferredArray. Keeping track of the matched count, add them to the appropriate object in the array of finalMatchedCocktails. */
         for cocktail in startingCocktails {
@@ -231,95 +231,96 @@ extension SearchResultsView {
             /** We use let _ = ... to loop over finalMatchContainers to append cocktails that match preferred components to the right section without creating a new array in the process */
             let _ = finalMatchContainers.map { resultViewSectionData in
                 
-            /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
-                if viewModel.enableResultsForMultipleBaseSpirits == false {
+                /** Then we want to match cocktails to sections by calculating the number of components that match the preferred array. */
+//                if viewModel.enableResultsForMultipleBaseSpirits == false {
                     if resultViewSectionData.matched == viewModel.selectedPreferredIngredients().reduce(0, { countMatches($0, for: $1, in: cocktail)}) {
+                        cocktail.nonmatchPreferences = findUnmatchedComponents(for: cocktail)
                         resultViewSectionData.cocktails.append(cocktail)
                     }
-                } else {
-                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
-                            resultViewSectionData.cocktails.append(cocktail)
-                        //print("the count match for \(cocktail.cocktailName) is \(countMatchesForMultipleSpirits(for: cocktail))")
-                    }
-                }
+//                } else {
+//                    if resultViewSectionData.matched == countMatchesForMultipleSpirits(for: cocktail) && resultViewSectionData.baseSpirit == returnMatchedBase(cocktail) && resultViewSectionData.cocktails.last != cocktail {
+//                        cocktail.nonmatchPreferences = findUnmatchedComponents(for: cocktail)
+//                        resultViewSectionData.cocktails.append(cocktail)
+//                    }
+//                }
             }
         }
         
         /** Finally, we then return an array of matching cocktails as an array of ResultSectionViewData objects, checking to make sure the sections aren't empty. */
         viewModel.sections.append(contentsOf: finalMatchContainers.filter({ !$0.cocktails.isEmpty}))
-         
+        
         /** (alternatively we do the same thing with compactMap and just cast the non-matches as optionals and compactMap will remove them for us)
-                i.e.
-            sections = finalMatchContainers.compactMap { resultSectionData in
-            return resultSectionData.cocktails.isEmpty ? nil : resultSectionData } */
+         i.e.
+         sections = finalMatchContainers.compactMap { resultSectionData in
+         return resultSectionData.cocktails.isEmpty ? nil : resultSectionData } */
         print("The cocktail count is \(cocktails.count)")
         viewModel.isLoading = false
     }
     
-    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
-        // compare preferredComponent against current cocktail of loop, then return number of matches.
-        var justBases = [String]()
-        var alreadyMatchedSpec = 0
-        if let booze = cocktail.compiledTags.booze {
-            for booze in booze {
-                if !viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-                    justBases.append(booze.name)
-                }
-            }
-        }
-
-        let matches = viewModel.cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
-            for spec in justBases {
-                if spec == component.name && alreadyMatchedSpec == 0 {
-                    partialResult += 1
-                    alreadyMatchedSpec += 1
-                }
-            }
-            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
-                    partialResult += 1
-                }
-        })
-        return matches
-    }
+//    private func countMatchesForMultipleSpirits(for cocktail: Cocktail) -> Int {
+//        // compare preferredComponent against current cocktail of loop, then return number of matches.
+//        var justBases = [String]()
+//        var alreadyMatchedSpec = 0
+//        if let booze = cocktail.compiledTags.booze {
+//            for booze in booze {
+//                if !viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
+//                    justBases.append(booze.name)
+//                }
+//            }
+//        }
+//
+//        let matches = viewModel.cocktailComponents.filter({ $0.isPreferred }).reduce(into: 0, { partialResult, component in
+//            for spec in justBases {
+//                if spec == component.name && alreadyMatchedSpec == 0 {
+//                    partialResult += 1
+//                    alreadyMatchedSpec += 1
+//                }
+//            }
+//            if convertAllTagsOmittingBaseSpirits(tags: cocktail.compiledTags, cocktail: cocktail).contains(component.name){
+//                    partialResult += 1
+//                }
+//        })
+//        return matches
+//    }
                                                                                         
-    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
-        var strings: [String] = [String]()
-        if let boozeComponents = tags.booze {
-            for booze in boozeComponents {
-                if viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
-                    strings.append(booze.name)
-                }
-            }
-        }
-        if let nA = tags.nA {
-            strings.append(contentsOf: nA.map({$0.name}))
-        }
-        if let flavors = tags.flavors {
-            strings.append(contentsOf: flavors.map({$0.rawValue}))
-        }
-        if let styles = tags.styles {
-            strings.append(contentsOf: styles.map({$0.rawValue}))
-        }
-        if let profiles = tags.profiles {
-            strings.append(contentsOf: profiles.map({$0.rawValue}))
-        }
-        return Array(Set(strings))
-        
-    }
+//    private func convertAllTagsOmittingBaseSpirits(tags: Tags, cocktail: Cocktail) -> [String] {
+//        var strings: [String] = [String]()
+//        if let boozeComponents = tags.booze {
+//            for booze in boozeComponents {
+//                if viewModel.baseSpiritsConvertedIntoStrings.contains(booze.name) {
+//                    strings.append(booze.name)
+//                }
+//            }
+//        }
+//        if let nA = tags.nA {
+//            strings.append(contentsOf: nA.map({$0.name}))
+//        }
+//        if let flavors = tags.flavors {
+//            strings.append(contentsOf: flavors.map({$0.rawValue}))
+//        }
+//        if let styles = tags.styles {
+//            strings.append(contentsOf: styles.map({$0.rawValue}))
+//        }
+//        if let profiles = tags.profiles {
+//            strings.append(contentsOf: profiles.map({$0.rawValue}))
+//        }
+//        return Array(Set(strings))
+//        
+//    }
 
-    private func returnMatchedBase(_ cocktail: Cocktail) -> String {
-        var matchedString = ""
-        if let boozeComponents = cocktail.compiledTags.booze {
-            for booze in boozeComponents {
-                for matched in viewModel.cocktailComponents.filter({ $0.isPreferred }) {
-                    if matched.name == booze.name && viewModel.baseSpiritsConvertedIntoStrings.contains(matched.name) {
-                        matchedString = matched.name
-                    }
-                }
-            }
-        }
-        return matchedString
-    }
+//    private func returnMatchedBase(_ cocktail: Cocktail) -> String {
+//        var matchedString = ""
+//        if let boozeComponents = cocktail.compiledTags.booze {
+//            for booze in boozeComponents {
+//                for matched in viewModel.cocktailComponents.filter({ $0.isPreferred }) {
+//                    if matched.name == booze.name && viewModel.baseSpiritsConvertedIntoStrings.contains(matched.name) {
+//                        matchedString = matched.name
+//                    }
+//                }
+//            }
+//        }
+//        return matchedString
+//    }
     
     // we had to move this into the view because it calls getFilteredCocktailsSwiftData() which can't be a static var.
     func removePreference(for component: CocktailComponent) {
@@ -377,7 +378,15 @@ extension SearchResultsView {
         return matches
     }
     
+    func findUnmatchedComponents(for cocktail: Cocktail ) -> [String] {
+        var componentArray = [String]()
+        for preferedComponent in viewModel.selectedPreferredIngredients() {
+            if !convertTagsAndSpecToStrings(for: cocktail).contains(preferedComponent.name) {
+                componentArray.append(preferedComponent.name)
+            }
+        }
+        return componentArray
+    }
+    
    
 }
-
-

--- a/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchCriteriaViewModel.swift
@@ -71,6 +71,8 @@ final class SearchCriteriaViewModel: ObservableObject {
  
     var searchText: String = ""
     var preferredCount = 0
+    var willLoadOnAppear = true
+    
     var sections = [ResultViewSectionData]()
     //var enableResultsForMultipleBaseSpirits = false
     var isLoading = true
@@ -196,6 +198,7 @@ final class SearchCriteriaViewModel: ObservableObject {
 extension SearchResultsView {
     
     func getFilteredCocktailsSwiftData()  {
+        print("This got fired")
         var startingCocktails: [Cocktail] = []
         viewModel.isLoading = true
         viewModel.resetSearchCriteria()

--- a/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
@@ -15,8 +15,22 @@ struct SearchResultsView: View {
     @Query(sort: \Cocktail.cocktailName) var cocktails: [Cocktail]
     @Environment(\.dismiss) var dismiss
     
+    
     var body: some View {
-        BackButton()
+        HStack{
+            Button{
+                dismiss()
+                viewModel.willLoadOnAppear = true
+            } label: {
+                Image(systemName: "chevron.backward")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 9)
+                    .bold()
+                    .tint(.cyan)
+            }
+            Spacer()
+        }
         VStack(alignment: .leading) {
             
             if viewModel.preferredCount > 0 {
@@ -58,6 +72,7 @@ struct SearchResultsView: View {
                                     withAnimation(.snappy) {
                                        removeUnwanted(for: selectedIngredient)
                                     }
+                                    
                                 }
                         }
                     }
@@ -73,7 +88,11 @@ struct SearchResultsView: View {
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear() {
-            getFilteredCocktailsSwiftData()
+            if viewModel.willLoadOnAppear == true {
+                getFilteredCocktailsSwiftData()
+                
+            }
+            viewModel.willLoadOnAppear = false
         }
     }
     

--- a/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
@@ -70,22 +70,6 @@ struct SearchResultsView: View {
            
             CocktailResultList(viewModel: viewModel, isLoading: $viewModel.isLoading)
                 .navigationBarBackButtonHidden(true)
-            if viewModel.multipleBaseSpiritsSelectedToEnableMenu {
-                Menu("Sort Results") {
-                    Button("By number of matches: Apply to a single cocktail.", action: {
-                        viewModel.enableResultsForMultipleBaseSpirits = false
-                        getFilteredCocktailsSwiftData()
-                    })
-                    Button("By Spirit: Separate your results based on the spirit.", action: {
-                        viewModel.enableResultsForMultipleBaseSpirits = true
-                        getFilteredCocktailsSwiftData()
-                    })
-                }
-                .padding(10)
-                .font(.headline).bold()
-                .buttonStyle(BlackNWhiteButton())
-                .frame(maxWidth: .infinity, alignment: .center)
-            }
         }
         .navigationBarTitleDisplayMode(.inline)
         .onAppear() {

--- a/MetaCocktailsSwiftData/Views/Subviews/Buttons/SearchButtonView.swift
+++ b/MetaCocktailsSwiftData/Views/Subviews/Buttons/SearchButtonView.swift
@@ -13,7 +13,7 @@ struct SearchButtonView: View {
  
 
     var body: some View {
-        if viewModel.selectedPreferredIngredients().count > 0 {
+        if viewModel.shouldShowSearchButton() {
             HStack{
             
                 NavigationLink{

--- a/MetaCocktailsSwiftData/Views/Subviews/Buttons/SearchButtonView.swift
+++ b/MetaCocktailsSwiftData/Views/Subviews/Buttons/SearchButtonView.swift
@@ -10,13 +10,13 @@ import SwiftUI
 struct SearchButtonView: View {
     @EnvironmentObject var viewModel: SearchCriteriaViewModel
 //    @State private var searchButtonOffset: CGFloat = 1000
-//    @Binding var isActive: Bool
+ 
+
     var body: some View {
         if viewModel.selectedPreferredIngredients().count > 0 {
             HStack{
-                
-                
-                NavigationLink {
+            
+                NavigationLink{
                     
                     SearchResultsView(viewModel: viewModel)
                     
@@ -40,6 +40,7 @@ struct SearchButtonView: View {
                         component.isUnwanted = false
                     }
                     viewModel.matchAllTheThings()
+                    
                 }) {
                     Image(systemName: "xmark")
                     
@@ -76,3 +77,4 @@ struct SearchButtonView: View {
     SearchButtonView()
         .environmentObject(SearchCriteriaViewModel())
 }
+


### PR DESCRIPTION
Filtering now works on each individual section of the search results. I really like the idea of limiting the filter options to one ingredient.

This also did something unexpected but super cool. It got rid of the need for the separate split base cocktail search. It effectively made it useless because now you can search for the split based type cocktail that you're looking for and an option will either show up or you can search for the same criteria but filter the results to omit whichever base spirit that you'd like to show results for. 

A good example for this is the Smoking Monkey Cocktail. Search Whisk(e)y + Lemon + Gin + Egg. The Smoking monkey is at the top, then the user can filter individual spirits out while the other ingredients remain.

This also cleans up a ton of unnecessary code from the view model and results view. How neat!

The way I achieved it was actually pretty simple. I added a nonMatchPreferencesArray directly to the cocktail object.

![Screenshot 2024-04-05 at 12 14 52 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/b89ceea0-2166-4881-a441-241cd6094dd9)

Then I added a small function that checks the selected preferences against the cocktail's ingredients. 

![Screenshot 2024-04-05 at 12 16 39 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/69224128-e867-4bb3-9b9e-07bb76b40aa2)

Then we run that function right before the cocktail gets added to the ResultViewSectionData to append the ingredients that don't match the specific cocktail.

![Screenshot 2024-04-05 at 12 19 31 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/b48746a0-b729-4804-80ec-442acde3c3e5)

Then the filtering  just happens on the COCKTAILRESULTSLIST view.

I'm pretty happy with this change so thank you for the guidance. 

I left the old code grayed out in case you want to change things.  But let me know what you think! 😀

