### PR TITLE
Added indexing to the model for faster query of the cocktail list.

### DIFF
--- a/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
+++ b/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
@@ -2534,6 +2534,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2563,6 +2564,7 @@
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/MetaCocktailsSwiftData/Model/Cocktail.swift
+++ b/MetaCocktailsSwiftData/Model/Cocktail.swift
@@ -8,6 +8,7 @@
 import SwiftData
 import SwiftUI
 
+@available(iOS 18, *)
 @Model
 class Cocktail: Equatable, Hashable {
     static func == (lhs: Cocktail, rhs: Cocktail) -> Bool {
@@ -16,6 +17,7 @@ class Cocktail: Equatable, Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(cocktailName)
     }
+    #Index<Cocktail>([\.cocktailName], [\.collectionName], [\.cocktailName, \.collectionName])
     
     var id = UUID()
     @Attribute(.unique) var cocktailName: String

--- a/MetaCocktailsSwiftData/Views/Tab Bar View/TabBarView.swift
+++ b/MetaCocktailsSwiftData/Views/Tab Bar View/TabBarView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct TabBarView: View {
     
-    @State private var selectedTab: TabBarComponents = .searchView
+    @State private var selectedTab: TabBarComponents = .cocktailListView
     
     var body: some View {
         


### PR DESCRIPTION
Moved the target iOS to 18.0

Added indexing for queries for cocktailName and collectionName. 

Moved the default loading view back to cocktailListView. 