### PR TITLE
Added basic custom ingredient functionality

### DIFF
--- a/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
+++ b/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
@@ -372,6 +372,7 @@
 		4DBFF8572B60AAFB0011B5B1 /* CableCar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF8562B60AAFB0011B5B1 /* CableCar.swift */; };
 		4DBFF8592B60AD800011B5B1 /* CableCar(W&G).swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF8582B60AD800011B5B1 /* CableCar(W&G).swift */; };
 		4DBFF85B2B60AFE60011B5B1 /* Carajillo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF85A2B60AFE60011B5B1 /* Carajillo.swift */; };
+		4DC420202C28C26500B0F88E /* CustomIngredientModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC4201F2C28C26500B0F88E /* CustomIngredientModalView.swift */; };
 		4DCB16F62BA239D60002D7D9 /* StreetAndFlynnSpecial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB16F52BA239D60002D7D9 /* StreetAndFlynnSpecial.swift */; };
 		4DCB16F82BA249800002D7D9 /* SugarPlum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB16F72BA249800002D7D9 /* SugarPlum.swift */; };
 		4DCB16FA2BA24A620002D7D9 /* SuttersMill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCB16F92BA24A620002D7D9 /* SuttersMill.swift */; };
@@ -866,6 +867,7 @@
 		4DBFF8562B60AAFB0011B5B1 /* CableCar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CableCar.swift; sourceTree = "<group>"; };
 		4DBFF8582B60AD800011B5B1 /* CableCar(W&G).swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CableCar(W&G).swift"; sourceTree = "<group>"; };
 		4DBFF85A2B60AFE60011B5B1 /* Carajillo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carajillo.swift; sourceTree = "<group>"; };
+		4DC4201F2C28C26500B0F88E /* CustomIngredientModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomIngredientModalView.swift; sourceTree = "<group>"; };
 		4DCB16F52BA239D60002D7D9 /* StreetAndFlynnSpecial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreetAndFlynnSpecial.swift; sourceTree = "<group>"; };
 		4DCB16F72BA249800002D7D9 /* SugarPlum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SugarPlum.swift; sourceTree = "<group>"; };
 		4DCB16F92BA24A620002D7D9 /* SuttersMill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuttersMill.swift; sourceTree = "<group>"; };
@@ -1465,6 +1467,7 @@
 				4D5DA08D2B9E8E6A00C14F1F /* AddBuildStepDetailView.swift */,
 				4D5DA0952B9EB43600C14F1F /* AddedIngredientView.swift */,
 				4D5DA0972B9EB46E00C14F1F /* AddBuildStepView.swift */,
+				4DC4201F2C28C26500B0F88E /* CustomIngredientModalView.swift */,
 			);
 			path = SubViews;
 			sourceTree = "<group>";
@@ -2006,6 +2009,7 @@
 				4DF408C62B60D4A100EF9A6E /* ChampsElysees.swift in Sources */,
 				F4C5C3E12B3B3F2E005B2261 /* IngredientType.swift in Sources */,
 				4DE33E072B915E5C00312EC3 /* Bensonhurst.swift in Sources */,
+				4DC420202C28C26500B0F88E /* CustomIngredientModalView.swift in Sources */,
 				4DA567E82B6DD90A003F6F04 /* MadusasFang.swift in Sources */,
 				4DBBA48E2B68963200179B8F /* Mezcalero.swift in Sources */,
 				4DBFF8232B5FB71E0011B5B1 /* ArmyNavy.swift in Sources */,

--- a/MetaCocktailsSwiftData/Model/Cocktails/Death and Co/DivisionBell.swift
+++ b/MetaCocktailsSwiftData/Model/Cocktails/Death and Co/DivisionBell.swift
@@ -22,6 +22,8 @@ var divisionBellSpec  = [CocktailIngredient(.juices(.lime), value: 0.75),
                          CocktailIngredient(.liqueurs(.maraschinoLiqueur), value: 0.5),
                          CocktailIngredient(.amari(.aperol), value: 0.75)]
 
+
+
 var divisionBellTags = Tags(profiles: [.light, .dry, .fruity],
                             styles: [.sour, .shaken],
                             booze: [Booze(.agaves(.mezcalAny))])

--- a/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
@@ -17,7 +17,7 @@ class CocktailIngredient: Codable, Hashable {
     let value: Double
     let unit: MeasurementUnit
     let prep: Prep?
-    let name: String?
+    let customIngredientName: String?
     
     
     init(_ ingredient: IngredientType, value: Double, unit: MeasurementUnit = .fluidOunces, prep: Prep? = nil, name: String? = nil) {
@@ -26,7 +26,7 @@ class CocktailIngredient: Codable, Hashable {
         self.unit = unit
         self.id = UUID()
         self.prep = prep
-        self.name = {
+        self.customIngredientName = {
             if ingredient.name != CustomIngredient.customIngredient.rawValue{
                 return ingredient.name
             } else {

--- a/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
@@ -8,6 +8,7 @@
 import Foundation
 import SwiftData
 
+
 @Model
 class CocktailIngredient: Codable, Hashable {
 
@@ -16,14 +17,23 @@ class CocktailIngredient: Codable, Hashable {
     let value: Double
     let unit: MeasurementUnit
     let prep: Prep?
+    let name: String?
     
     
-    init(_ ingredient: IngredientType, value: Double, unit: MeasurementUnit = .fluidOunces, prep: Prep? = nil) {
+    init(_ ingredient: IngredientType, value: Double, unit: MeasurementUnit = .fluidOunces, prep: Prep? = nil, name: String? = nil) {
         self.ingredient = ingredient
         self.value = value
         self.unit = unit
         self.id = UUID()
         self.prep = prep
+        self.name = {
+            if ingredient.name != CustomIngredient.customIngredient.rawValue{
+                return ingredient.name
+            } else {
+                return name
+            }
+        }()
+      
     }
     
     func localizedVolumetricString(location: Location) -> String {
@@ -72,6 +82,67 @@ class CocktailIngredient: Codable, Hashable {
 }
 
 
-
-
-
+// MARK: Original Model
+//
+//@Model
+//class CocktailIngredient: Codable, Hashable {
+//
+//    let id: UUID
+//    let ingredient: IngredientType
+//    let value: Double
+//    let unit: MeasurementUnit
+//    let prep: Prep?
+//    
+//    
+//    init(_ ingredient: IngredientType, value: Double, unit: MeasurementUnit = .fluidOunces, prep: Prep? = nil) {
+//        self.ingredient = ingredient
+//        self.value = value
+//        self.unit = unit
+//        self.id = UUID()
+//        self.prep = prep
+//    }
+//    
+//    func localizedVolumetricString(location: Location) -> String {
+//        switch location {
+//        case .usa:
+//            return "\(value) \(unit)"
+//        case .world:
+//            return "\(self.value * 29.5735) mls"
+//        }
+//    }
+//    
+//    // MARK: Equatable + Hashable Conformance
+//    
+//    static func == (lhs: CocktailIngredient, rhs: CocktailIngredient) -> Bool {
+//        lhs.id > rhs.id
+//    }
+//    
+//    func hash(into hasher: inout Hasher) {
+//        hasher.combine(id)
+//    }
+//    
+//    // MARK: - @Model codable conformance
+//
+//    enum CodingKeys: CodingKey {
+//        case id, ingredient, value, unit, prep
+//    }
+//
+//    required init(from decoder: Decoder) throws {
+//        let container = try decoder.container(keyedBy: CodingKeys.self)
+//        self.id = try container.decode(UUID.self, forKey: .id)
+//        self.ingredient = try container.decode(IngredientType.self, forKey: .ingredient)
+//        self.value = try container.decode(Double.self, forKey: .value)
+//        self.unit = try container.decode(MeasurementUnit.self, forKey: .unit)
+//        self.prep = try container.decode(Prep.self, forKey: .prep)
+//    }
+//
+//    func encode(to encoder: Encoder) throws {
+//        var container = encoder.container(keyedBy: CodingKeys.self)
+//        try container.encode(id, forKey: .id)
+//        try container.encode(value, forKey: .value)
+//        try container.encode(ingredient, forKey: .ingredient)
+//        try container.encode(unit, forKey: .unit)
+//        try container.encode(prep, forKey: .prep
+//        )
+//    }
+//}

--- a/MetaCocktailsSwiftData/Model/Components/Ingredients/IngredientType.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredients/IngredientType.swift
@@ -30,6 +30,8 @@ enum IngredientType: Codable{
     case bitters(Bitters)
     case amari(Amaro)
     
+    case customIngredients(CustomIngredient)
+    
 
     
     var tags: Tags {
@@ -73,7 +75,11 @@ enum IngredientType: Codable{
             return bitters.tags
         case .amari(let amaro):
             return amaro.tags
+        case .customIngredients(let customIngredient):
+            return customIngredient.tags
         }
+ 
+  
     }
     
     var name: String {
@@ -116,6 +122,8 @@ enum IngredientType: Codable{
             return bitters.rawValue
         case .amari(let amaro):
             return amaro.rawValue
+        case .customIngredients(let customIngredient):
+            return customIngredient.rawValue
         }
     }
     
@@ -160,8 +168,38 @@ enum IngredientType: Codable{
             return "Bitters"
         case .amari:
             return "Amari"
+        case .customIngredients:
+            return "Custom Ingredient"
         }
+    
     }
+}
+
+enum IngredientCategory: String, Codable, CaseIterable  {
+    
+    case syrups            = "Syrup"
+    case juices            = "Juice"
+    case herbs             = "Herbs"
+    case fruit             = "Fruit"
+    case seasoning         = "Seasoning"
+    case soda              = "Sodas"
+    case otherNonAlc       = "Other N/A"
+    case agaves            = "Agave"
+    case brandies          = "Brandy"
+    case gins              = "Gin"
+    case otherAlcohol      = "Other Alcohol"
+    case rums              = "Rum"
+    case vodkas            = "Vodka"
+    case whiskies          = "Whiskies"
+    case liqueurs          = "Liqueurs"
+    case fortifiedWines    = "Fortified Wine"
+    case wines             = "Wine"
+    case bitters           = "Bitters"
+    case amari             = "Amari"
+    case customIngredients = "Custom Ingredient"
+    
+    
+    
 }
 
 enum MeasurementUnit: String, Codable, CaseIterable {

--- a/MetaCocktailsSwiftData/Model/Components/Ingredients/NonAlchololicIngredients.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredients/NonAlchololicIngredients.swift
@@ -27,6 +27,24 @@ struct NAIngredients: Codable, Hashable, Equatable {
     }
     
 }
+enum CustomIngredient: String, Codable, CaseIterable {
+    
+    case customIngredient  = "Custom Ingredient"
+    
+    var nAComponent: CocktailComponent {
+        return CocktailComponent(for: NAIngredients(.customIngredients(self)))
+    }
+    
+    var tags: Tags {
+        switch self {
+        case .customIngredient:
+            Tags(booze: [Booze(.customIngredients(.customIngredient))])
+        }
+    }
+    
+    
+}
+
 enum Juice: String, Codable, CaseIterable {
     case appleCider           = "Apple Cider"
     case carrotJuice          = "Carrot Juice (Fresh)"
@@ -37,6 +55,7 @@ enum Juice: String, Codable, CaseIterable {
     case lime                 = "Lime Juice (Fresh)"
     case orange               = "Orange Juice (Fresh)"
     case pineappleJuice       = "Pineapple Juice (Fresh)"
+  
     
     var nAComponent: CocktailComponent {
         return CocktailComponent(for: NAIngredients(.juices(self)))
@@ -62,6 +81,7 @@ enum Juice: String, Codable, CaseIterable {
             Tags(flavors: [.carrot], profiles: [.vegetal], nA: [NAIngredients(.juices(self))])
         case .appleCider:
             Tags(flavors: [.apple, .bakingSpices], nA: [NAIngredients(.juices(self))])
+       
         }
     }
 }
@@ -93,6 +113,7 @@ enum Syrup: String, Codable, CaseIterable {
     case simple                  = "Simple Syrup"
     case vanilla                 = "Vanilla Syrup"
     case violetteSyrup           = "Violette Syrup"
+
     
     var nAComponent: CocktailComponent {
         return CocktailComponent(for: NAIngredients(.syrups(self)))
@@ -152,6 +173,7 @@ enum Syrup: String, Codable, CaseIterable {
             Tags(flavors: [.maple], nA: [NAIngredients(.syrups(self))])
         case .gommeSyrup:
             Tags(nA: [NAIngredients(.syrups(self))])
+     
         }
     }
     
@@ -164,6 +186,7 @@ enum Herbs: String, Codable, CaseIterable {
     case mint                 = "Mint Leaves"
     case sage                 = "Sage Leaves"
     case tarragon             = "Tarragon Sprig"
+   
     
     var nAComponent: CocktailComponent {
         return CocktailComponent(for: NAIngredients(.herbs(self)))
@@ -180,6 +203,7 @@ enum Herbs: String, Codable, CaseIterable {
             Tags(flavors: [.cilantro], profiles: [.herbal, .aromatic], nA: [NAIngredients(.herbs(self))])
         case .tarragon:
             Tags(flavors: [.tarragon], profiles: [.herbal, .aromatic], nA: [NAIngredients(.herbs(self))])
+     
         }
     }
 }
@@ -198,6 +222,7 @@ enum Fruit: String, Codable, CaseIterable {
     case seasonalBerries      = "Seasonal Berries"
     case strawberryHalf       = "Strawberry Half"
     case pineapple            = "Pineapple Wedge"
+
     
     var nAComponent: CocktailComponent {
         return CocktailComponent(for: NAIngredients(.fruit(self)))
@@ -230,6 +255,7 @@ enum Fruit: String, Codable, CaseIterable {
             Tags(flavors: [.lime], nA: [NAIngredients(.fruit(self))])
         case .lemons:
             Tags(flavors: [.lemon], nA: [NAIngredients(.fruit(self))])
+      
         }
     }
 }
@@ -240,6 +266,7 @@ enum Seasoning: String, Codable, CaseIterable {
     case saline               = "Saline 3:1"
     case mineralSaline        = "Mineral Saline"
     case pepper               = "Ground black pepper (fresh)"
+    
    
     
     var nAComponent: CocktailComponent {
@@ -257,6 +284,7 @@ enum Seasoning: String, Codable, CaseIterable {
             Tags(nA: [NAIngredients(.seasoning(self))])
         case .pepper:
             Tags(flavors: [.blackPepper], nA: [NAIngredients(.seasoning(self))])
+      
         }
     }
 }
@@ -269,6 +297,7 @@ enum Soda: String, Codable, CaseIterable {
     case lemonMintSoda        = "Lemon Mint San Pellegrino"
     case sodaWater            = "Soda Water"
     case sparklingWater       = "Sparkling Water"
+    
     
     
     var nAComponent: CocktailComponent {
@@ -289,6 +318,7 @@ enum Soda: String, Codable, CaseIterable {
             Tags(flavors: [.lemon, .mint], profiles: [.effervescent], nA: [NAIngredients(.soda(self))])
         case .feverTreeAromatic:
             Tags( profiles: [.effervescent], nA: [NAIngredients(.soda(self))])
+        
         }
     }
 }
@@ -331,6 +361,7 @@ enum OtherNA: String, Codable, CaseIterable {
     case vanillaExtract       = "Vanilla Extract (Real)"
     case whitePeachPure       = "White Peach Puree"
     case worcestershire       = "Worcestershire"
+
     
     var nAComponent: CocktailComponent {
         return CocktailComponent(for: NAIngredients(.otherNonAlc(self)))
@@ -412,6 +443,9 @@ enum OtherNA: String, Codable, CaseIterable {
             Tags(flavors: [.coffee,.espresso], nA: [NAIngredients(.otherNonAlc(self))])
         case .nutmegGrated:
             Tags(flavors: [.nutmeg], nA: [NAIngredients(.otherNonAlc(self))])
+        
         }
     }
+    
+    
 }

--- a/MetaCocktailsSwiftData/Views/CocktailBatchingCalculator/CBCViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CocktailBatchingCalculator/CBCViewModel.swift
@@ -53,13 +53,20 @@ final class CBCViewModel: ObservableObject {
     
     
     func convertIngredientsToBatchCellData()  {
+    
+        
         var quantifiableIngredients = [BottleBatchedCellData]()
         var totalVolume = 0.0
         var ingredientVolume = 0.0
         for ingredient in loadedCocktailData.ingredients {
             
             if ingredient.isIncluded {
-                
+                var ingredientName = {
+                    if let name = ingredient.ingredient.name {
+                        return name
+                    }
+                    return ingredient.ingredient.ingredient.name
+                }()
                 var modifiedMeasurement = 0.0
                 /// go through all the modified measurement units and calculate the difference to oz conversion to later be converted into mls.
                 
@@ -80,7 +87,7 @@ final class CBCViewModel: ObservableObject {
                 }
                 
                 totalVolume += ingredientVolume
-                quantifiableIngredients.append(BottleBatchedCellData(ingredientName: ingredient.ingredient.ingredient.name,
+                quantifiableIngredients.append(BottleBatchedCellData(ingredientName: ingredientName,
                                                                whole1LBottles: (ingredientVolume / 1000).rounded(.down),
                                                                remaining1LMls: Int(ingredientVolume.truncatingRemainder(dividingBy: 1000)),
                                                                whole750mlBottles: (ingredientVolume / 750).rounded(.down),

--- a/MetaCocktailsSwiftData/Views/CocktailBatchingCalculator/CBCViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CocktailBatchingCalculator/CBCViewModel.swift
@@ -61,8 +61,8 @@ final class CBCViewModel: ObservableObject {
         for ingredient in loadedCocktailData.ingredients {
             
             if ingredient.isIncluded {
-                var ingredientName = {
-                    if let name = ingredient.ingredient.name {
+                let ingredientName = {
+                    if let name = ingredient.ingredient.customIngredientName {
                         return name
                     }
                     return ingredient.ingredient.ingredient.name

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -14,6 +14,7 @@ import Observation
     //AddIngredientView
     var isShowingingredientAlert: Bool = false
     var ingredientName = ""
+    var customIngredientName = ""
     var ingredientAmount = 0.0
     var ingredientType: IngredientType = IngredientType.agaves(.tequilaAny)
     var selectedMeasurementUnit = MeasurementUnit.fluidOunces
@@ -71,6 +72,7 @@ import Observation
     }
     func clearIngredientData() {
         ingredientName = ""
+        customIngredientName = ""
         ingredientAmount = 0
         selectedMeasurementUnit = .fluidOunces
     }
@@ -90,7 +92,7 @@ import Observation
             }
         }
         
-        return IngredientType.seasoning(.nutmeg)
+        return IngredientType.customIngredients(.customIngredient)
     }
     
     
@@ -101,6 +103,10 @@ import Observation
     func ingredientIsValid() -> Bool {
         
         return ingredientAmount != 0.0 && ingredientName != ""
+    }
+    
+    func customIngredientIsValid() -> Bool {
+        return ingredientAmount != 0.0 && customIngredientName != ""
     }
     // Can't add cocktail alert
     

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredientDetailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredientDetailView.swift
@@ -11,8 +11,12 @@ struct AddIngredientDetailView: View {
     
     @Bindable var viewModel: AddCocktailViewModel
     @FocusState private var keyboardFocused: Bool
+    @FocusState private var customIngredientKeyboardFocused: Bool
     @FocusState private var amountKeyboardFocus: Bool
     @Environment(\.dismiss) private var dismiss
+    @State private var isShowingCustomIngredientModal = false
+    @State private var isShowingCustomIngredientTextField = false
+    
     
     var body: some View {
         ZStack{
@@ -63,7 +67,21 @@ struct AddIngredientDetailView: View {
                     
                     .listStyle(.plain)
                     .listRowBackground(Color.black)
-    
+                    if viewModel.ingredientName != "" {
+                        Button {
+                            isShowingCustomIngredientTextField.toggle()
+                        } label: {
+                            Text("Create Custom Ingredient")
+                        }
+                        .buttonStyle(BlackNWhiteButton())
+                        
+                        .listRowBackground(Color.black)
+                    }
+                    if isShowingCustomIngredientTextField {
+                        
+                        TextField("Enter Ingredient Name", text: $viewModel.customIngredientName)
+                    }
+
                     
                 }
                 .scrollContentBackground(.hidden)
@@ -91,14 +109,26 @@ struct AddIngredientDetailView: View {
                 }
                 
                 Button {
-                    if viewModel.ingredientIsValid() {
-                        viewModel.addedIngredients.append(CocktailIngredient(viewModel.validateCurrentSelectedComponent(for: viewModel.currentSelectedComponent),
-                                                                             value: viewModel.ingredientAmount, 
-                                                                             unit: viewModel.selectedMeasurementUnit))
-                        viewModel.clearIngredientData()
-                        dismiss()
+                    if viewModel.customIngredientName == "" {
+                        if viewModel.ingredientIsValid() {
+                            viewModel.addedIngredients.append(CocktailIngredient(viewModel.validateCurrentSelectedComponent(
+                                for: viewModel.currentSelectedComponent),
+                                                                                 value: viewModel.ingredientAmount,
+                                                                                 unit: viewModel.selectedMeasurementUnit))
+                            viewModel.clearIngredientData()
+                            dismiss()
+                        } else {
+                            viewModel.isShowingingredientAlert.toggle()
+                        }
                     } else {
-                        viewModel.isShowingingredientAlert.toggle()
+                        if viewModel.customIngredientIsValid() {
+                            viewModel.addedIngredients.append(CocktailIngredient(IngredientType.customIngredients(.customIngredient), value: viewModel.ingredientAmount, unit: viewModel.selectedMeasurementUnit, name: viewModel.customIngredientName))
+                            
+                            viewModel.clearIngredientData()
+                            dismiss()
+                        } else {
+                            viewModel.isShowingingredientAlert.toggle()
+                        }
                     }
                     
                 } label: {

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddedIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddedIngredientView.swift
@@ -19,8 +19,13 @@ struct AddedIngredientView: View {
         Section(header: Text("Ingredients")) {
             
             List{
-                ForEach(viewModel.addedIngredients, id: \.ingredient.name) { ingredient in
-                    Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.ingredient.name)")
+                ForEach(viewModel.addedIngredients, id: \.id) { ingredient in
+                    if ingredient.ingredient.name != "Custom Ingredient" {
+                        Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.ingredient.name)")
+                    } else {
+                        Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.name!)")
+                    }
+                    
                 }
                 .onDelete(perform: { indexSet in
                     viewModel.addedIngredients.remove(atOffsets: indexSet)

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddedIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddedIngredientView.swift
@@ -23,7 +23,7 @@ struct AddedIngredientView: View {
                     if ingredient.ingredient.name != "Custom Ingredient" {
                         Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.ingredient.name)")
                     } else {
-                        Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.name!)")
+                        Text("\(NSNumber(value: ingredient.value)) \(ingredient.unit.rawValue) \(ingredient.customIngredientName!)")
                     }
                     
                 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/CustomIngredientModalView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/CustomIngredientModalView.swift
@@ -1,0 +1,22 @@
+//
+//  CustomIngredientModalView.swift
+//  MetaCocktailsSwiftData
+//
+//  Created by James Menkal on 6/23/24.
+//
+
+import SwiftUI
+
+struct CustomIngredientModalView: View {
+    @State var ingredientName = ""
+    @State var ingredientType: IngredientType = .customIngredients(.customIngredient)
+   
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    CustomIngredientModalView()
+}

--- a/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
+++ b/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
@@ -350,20 +350,33 @@ struct SpecView: View {
                     
                     ForEach(orderSpec(), id: \.id) { ingredient in
                         let number = NSNumber(value: ingredient.value)
-                        HStack {
-                            Text("\(number) \(ingredient.unit.rawValue)")
-                                .font(Layout.specMeasurement)
-                            if ingredient.prep != nil {
-                                NavigationLink {
-                                    PrepRecipeView(prep: ingredient.prep!)
-                                } label: {
-                                    Text(ingredient.ingredient.name)
+                        
+                        if ingredient.ingredient.name != "Custom Ingredient" {
+                            HStack {
+                                Text("\(number) \(ingredient.unit.rawValue)")
+                                    .font(Layout.specMeasurement)
+                                
+                                if ingredient.prep != nil {
+                                    NavigationLink {
+                                        PrepRecipeView(prep: ingredient.prep!)
+                                    } label: {
+                                        Text(ingredient.ingredient.name)
+                                            .font(Layout.body)
+                                            .tint(.cyan)
+                                    }
+                                } else {
+                                    Text("\(ingredient.ingredient.name)")
                                         .font(Layout.body)
-                                        .tint(.cyan)
                                 }
-                            } else {
-                                Text("\(ingredient.ingredient.name)")
-                                    .font(Layout.body)
+                            }
+                        } else {
+                            HStack {
+                                Text("\(number) \(ingredient.unit.rawValue)")
+                                    .font(Layout.specMeasurement)
+                                if let name = ingredient.name {
+                                    Text("\(name)")
+                                        .font(Layout.body)
+                                }
                             }
                         }
                     }
@@ -395,6 +408,7 @@ struct SpecView: View {
         orderedSpec.append(contentsOf: cocktail.spec.filter({ $0.ingredient.category == "Other Alcohol"}))
         orderedSpec.append(contentsOf: cocktail.spec.filter({ $0.ingredient.category == "Sodas"}))
         orderedSpec.append(contentsOf: cocktail.spec.filter({ $0.ingredient.category == "Wine"}))
+        orderedSpec.append(contentsOf: cocktail.spec.filter({ $0.ingredient.category == "Custom Ingredient"}))
         
         return orderedSpec
     }

--- a/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
+++ b/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
@@ -373,7 +373,7 @@ struct SpecView: View {
                             HStack {
                                 Text("\(number) \(ingredient.unit.rawValue)")
                                     .font(Layout.specMeasurement)
-                                if let name = ingredient.name {
+                                if let name = ingredient.customIngredientName {
                                     Text("\(name)")
                                         .font(Layout.body)
                                 }

--- a/MetaCocktailsSwiftData/Views/Subviews/Cells/LoadedCocktailIngredientCell.swift
+++ b/MetaCocktailsSwiftData/Views/Subviews/Cells/LoadedCocktailIngredientCell.swift
@@ -16,10 +16,10 @@ struct LoadedCocktailIngredientCell: View {
     
     var body: some View {
         HStack {
-            if ingredient.ingredient.name == nil {
+            if ingredient.ingredient.customIngredientName == nil {
                 Text("\(ingredient.ingredient.ingredient.name)")
             } else {
-                if let name = ingredient.ingredient.name {
+                if let name = ingredient.ingredient.customIngredientName {
                     Text("\(name)")
                 }
             }

--- a/MetaCocktailsSwiftData/Views/Subviews/Cells/LoadedCocktailIngredientCell.swift
+++ b/MetaCocktailsSwiftData/Views/Subviews/Cells/LoadedCocktailIngredientCell.swift
@@ -16,8 +16,15 @@ struct LoadedCocktailIngredientCell: View {
     
     var body: some View {
         HStack {
+            if ingredient.ingredient.name == nil {
+                Text("\(ingredient.ingredient.ingredient.name)")
+            } else {
+                if let name = ingredient.ingredient.name {
+                    Text("\(name)")
+                }
+            }
             
-            Text("\(ingredient.ingredient.ingredient.name)")
+            
                 
             
             Spacer()

--- a/MetaCocktailsSwiftData/Views/Subviews/Cells/SimpleBatchCell.swift
+++ b/MetaCocktailsSwiftData/Views/Subviews/Cells/SimpleBatchCell.swift
@@ -13,6 +13,7 @@ struct SimpleBatchCell: View {
     
     var body: some View {
         HStack{
+            
             Text(quantifiedBatchedIngredient.ingredientName)
             Spacer()
             Text("\(quantifiedBatchedIngredient.totalMls)ml")


### PR DESCRIPTION

![Screenshot 2024-06-26 at 2 08 59 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/d1e24703-944d-44cf-a8bb-e8339f8c683c)

The first thing I did was change the init on CocktailIngredient Model to include "name" as an optional string. 

![Screenshot 2024-06-26 at 2 12 02 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/e599bb1f-7d0e-492c-9513-310094bf0b92)
Then I created a CustomIngredient enum that would satisfy the non-optional IngredientType so that when the user inputs a custom ingredient, it has a default IngredientType. 

In the search function, we can show a "Custom Ingredients" section that the user can find and include their own ingredients. But I doubt that the user would need to search fro their own custom ingredient since they are the only one creating cocktail with that particular ingredient. 

In ADDINGREDIENTSDETAILVIEW, I modified a couple of things:

First:
![Screenshot 2024-06-26 at 2 23 07 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/e202716d-c41a-4c03-8580-419199bf3742)

I created a button that shows up only after the user searches for an ingredient, to avoid the user inputing an ingredient that already exists. 

If they click on the button a second text field pops down that allows the user to input a custom ingredient name. 

Second:
![Screenshot 2024-06-26 at 2 25 59 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/d734df7e-5a75-47b7-afeb-5747df9847ea)
I added an if/else statement to check if the viewModel.customIngredientsName var is empty, this is the var that is bound to the custom name text field. If it is empty, it's business as usual.

if it isn't though, it adds the CocktailIngredient to the array in the viewModel a slightly different way.

It first checks to see if it is valid:
![Screenshot 2024-06-26 at 2 30 09 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/cab2a6eb-90bf-4c49-8754-29bc8c18cd28)

then it adds the .customIngredient as it's ingredient type, value, measurement unit, and optional name as the viewModel.customIngredientName.

Success! 

Now we just need to change the logic for the names on the recipe view and cocktail batching calculator as shown below:

![Screenshot 2024-06-26 at 2 34 25 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/e28aa5d2-9d70-4c89-9e30-6e9485f97205)
![Screenshot 2024-06-26 at 2 36 03 AM](https://github.com/MatthewHunt84/MetaCocktailsSwiftData/assets/95845784/5ca59eb4-40b2-4028-ab4b-01bcb1ef70ff)


