### PR TITLE
Sub categories show up in search terms

### DIFF
--- a/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredient.swift
@@ -306,10 +306,10 @@ class IngredientBase: Codable, Hashable {
     var tags: Tags?
     var prep: Prep?
     var isCustom: Bool
-    var subCategories: [SubCategories]
+    var subCategories: [String]
 
     
-    init(name: String, info: String? = nil, category: Category, tags: Tags? = Tags(), prep: Prep?, isCustom: Bool = false, subCategory: [SubCategories] = []) {
+    init(name: String, info: String? = nil, category: Category, tags: Tags? = Tags(), prep: Prep?, isCustom: Bool = false, subCategory: [String] = []) {
      
         self.name = name
         self.info = info
@@ -318,18 +318,18 @@ class IngredientBase: Codable, Hashable {
         self.prep = prep
         self.isCustom = isCustom
         self.subCategories = {
-            var subCategories: [SubCategories] = []
+            var tempSubCategories: [String] = []
             let subCategoryStrings: [String] = SubCategories.allCases.map({$0.rawValue})
             if let tags = tags {
                 if let booze = tags.booze {
                     for alcohol in booze {
                         if subCategoryStrings.contains(alcohol.name) {
-                            subCategories.append(contentsOf: SubCategories.allCases.filter({ $0.rawValue == alcohol.name}))
+                            tempSubCategories.append(alcohol.name)
                         }
                     }
                 }
             }
-            return subCategories
+            return tempSubCategories
         }()
     }
     
@@ -355,7 +355,7 @@ class IngredientBase: Codable, Hashable {
         self.prep = try container.decode(Prep.self, forKey: .prep)
         self.info = try container.decode(String.self, forKey: .info)
         self.isCustom = try container.decode(Bool.self, forKey: .isCustom)
-        self.subCategories = try container.decode([SubCategories].self, forKey: .subCategories)
+        self.subCategories = try container.decode([String].self, forKey: .subCategories)
     }
     
     func encode(to encoder: Encoder) throws {

--- a/MetaCocktailsSwiftData/Model/Components/Ingredients/Alcohol.swift
+++ b/MetaCocktailsSwiftData/Model/Components/Ingredients/Alcohol.swift
@@ -26,7 +26,12 @@ struct Booze: Codable, Hashable, Equatable {
     }
 }
 
-enum Agave: String, Codable, CaseIterable {
+protocol BoozeTagsProtocol {
+    var tags: Tags { get }
+}
+
+
+enum Agave: String, Codable, CaseIterable, BoozeTagsProtocol {
     
     case elTesoroRepo              = "El Tesoro Reposado"
     case mezcalAny                 = "Mezcal"
@@ -103,7 +108,7 @@ enum Agave: String, Codable, CaseIterable {
 }
 
 
-enum Brandy: String, Codable, CaseIterable {
+enum Brandy: String, Codable, CaseIterable, BoozeTagsProtocol {
     case appleBrandy          = "Apple Brandy"
     case armagnac             = "Armagnac"
     case cognacVSOP           = "Cognac (VSOP)"
@@ -161,7 +166,7 @@ enum Brandy: String, Codable, CaseIterable {
     }
 }
 
-enum Gin: String, Codable, CaseIterable {
+enum Gin: String, Codable, CaseIterable, BoozeTagsProtocol {
     
     case agedBolsGenever      = "Bols Genever Barrel Aged"
     case fordsGin             = "Fords Gin"
@@ -237,7 +242,7 @@ enum Gin: String, Codable, CaseIterable {
 }
 
 // Other can be Aquavit, Malort, Absinthe etc.
-enum OtherAlcohol: String, Codable, CaseIterable {
+enum OtherAlcohol: String, Codable, CaseIterable, BoozeTagsProtocol {
     case absinthe                 = "Absinthe"
     case bataviaArrack            = "Batavia Arrack"
     case burdockRootTincture      = "Burdock Root Tincture"
@@ -287,7 +292,7 @@ enum OtherAlcohol: String, Codable, CaseIterable {
     }
 }
 
-enum Rum: String, Codable, CaseIterable {
+enum Rum: String, Codable, CaseIterable, BoozeTagsProtocol {
     case appletonEstateSignatureBlend = "Appleton Estate Signature Blend"
     case appleton12                   = "Appleton 12 year"
     case avuaPrata                    = "Avua Prata Cachaca"
@@ -420,7 +425,7 @@ enum Rum: String, Codable, CaseIterable {
     }
 }
 
-enum Vodka: String, Codable, CaseIterable {
+enum Vodka: String, Codable, CaseIterable, BoozeTagsProtocol {
     case peanutButterVodka       = "Vodka (Peanut Butter Infused)"
     case roaringForkVodka        = "Roaring Fork Vodka"
     case stGeorgeGreenChileVodka = "St. George Green Chile Vodka"
@@ -460,7 +465,7 @@ enum Vodka: String, Codable, CaseIterable {
     }
 }
 
-enum Whiskey: String, Codable, CaseIterable {
+enum Whiskey: String, Codable, CaseIterable, BoozeTagsProtocol {
     case aberlourAbundah       = "Aberlour Abundah"
     case Ardbeg                = "Ardbeg 10"
     case americanWhiskeyAny    = "American Whiskey"
@@ -629,7 +634,7 @@ enum Whiskey: String, Codable, CaseIterable {
         return CocktailComponent(for: Booze(.whiskies(self)))
     }
 }
-enum Liqueur: String, Codable, CaseIterable {
+enum Liqueur: String, Codable, CaseIterable, BoozeTagsProtocol {
     case allspiceDram         = "Allspice Dram"
     case aelredMelonApertif   = "Aelred Melon Aperitif"
     case amaretto             = "Amaretto"
@@ -792,7 +797,7 @@ enum Liqueur: String, Codable, CaseIterable {
     }
 
 }
-enum FortifiedWine: String, Codable, CaseIterable {
+enum FortifiedWine: String, Codable, CaseIterable, BoozeTagsProtocol {
     case aeDorPineauDeCharantes = "Pineau des Charentes Blanc"
     case amontillado            = "Amontillado Sherry"
     case blancVermouth          = "Blanc Vermouth"
@@ -915,7 +920,7 @@ enum FortifiedWine: String, Codable, CaseIterable {
     }
 }
 
-enum Wine: String, Codable, CaseIterable {
+enum Wine: String, Codable, CaseIterable, BoozeTagsProtocol {
     case bourgogneAligote     = "Bourgogne Aligote"
     case champagne            = "Champagne"
     case dryRedWine           = "Dry Red Wine"
@@ -931,7 +936,7 @@ enum Wine: String, Codable, CaseIterable {
     }
 
 }
-enum Bitters: String, Codable, CaseIterable {
+enum Bitters: String, Codable, CaseIterable, BoozeTagsProtocol {
     case aromaticBitters       = "Aromatic Bitters"
     case angosturaBitters      = "Angostura Bitters"
     case appleBitters          = "Apple Bitters"
@@ -1009,7 +1014,7 @@ enum Bitters: String, Codable, CaseIterable {
     }
 }
 
-enum Amaro: String, Codable, CaseIterable {
+enum Amaro: String, Codable, CaseIterable, BoozeTagsProtocol {
     
     case amargoVallet         = "Amargo-Vallet"
     case amaroAny             = "Amaro"

--- a/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail Result List View/ResultViewSectionData.swift
@@ -10,8 +10,8 @@ import SwiftUI
 class ResultViewSectionData {
     
     let id = UUID()
-    let sectionsPreferredCount: Int
-    let matched: Int
+    var sectionsPreferredCount: Int
+    var matched: Int
     var cocktails: [CocktailsAndMissingIngredients]
     
     init(count: Int, matched: Int, cocktails: [CocktailsAndMissingIngredients]) {
@@ -22,7 +22,7 @@ class ResultViewSectionData {
 }
 
 
-struct CocktailsAndMissingIngredients {
+struct CocktailsAndMissingIngredients: Equatable {
     
     let id = UUID()
     var missingIngredients: [String]

--- a/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
+++ b/MetaCocktailsSwiftData/Views/Recipe View/RecipeView.swift
@@ -34,13 +34,7 @@ struct RecipeView: View {
                
                 .task {
                     prepItems = viewModel.findPrepItems()
-                    for spec in viewModel.cocktail.spec {
-                        if !spec.ingredientBase.subCategories.isEmpty {
-                            for s in spec.ingredientBase.subCategories {
-                                print("\(spec.ingredientBase.name) has a sub category of \(s.rawValue)")
-                            }
-                        }
-                    }
+                    
                 }
             }
         }

--- a/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchResultsView.swift
@@ -135,6 +135,7 @@ struct SearchedCocktailTitleHeader: View {
             if matched - searched < 0 {
                 ForEach(0..<(searched - matched), id: \.self) { nonMatch in
                     Image(systemName: "circle.fill")
+                        .foregroundStyle(.gray)
                 }
             }
             

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
@@ -15,6 +15,7 @@ struct BasicSearchViewWithDataQuery: View {
     @Query var cocktails: [Cocktail]
     @Environment(\.modelContext) var modelContext
    
+   
     var body: some View {
         NavigationStack {
             HStack {
@@ -58,7 +59,7 @@ struct ThumbsUpOrDownIngredientSearchList: View {
                         .autocorrectionDisabled(true)
                         .onChange(of: viewModel.currentComponentSearchName, initial: true) { old, new in
                             viewModel.currentComponentSearchName = new
-                            viewModel.filteredIngredients = viewModel.matchAllIngredients(ingredients: ingredients.map({$0.name}), subCategories: viewModel.subCategoryStrings)
+                            viewModel.filteredIngredients = viewModel.matchAllIngredientsAndSubcategories(ingredients: ingredients.map({$0.name}), subCategories: viewModel.subCategoryStrings)
                         }
                     if !viewModel.currentComponentSearchName.isEmpty {
                         Button {
@@ -94,6 +95,7 @@ struct ThumbsUpOrDownIngredientSearchList: View {
 struct SearchForCocktailsButton: View {
     @Bindable var viewModel: SearchViewModel
     @Environment(\.modelContext) var modelContext
+   
     var body: some View {
         NavigationLink {
             SearchResultsViewDataQueries(viewModel: viewModel)
@@ -141,15 +143,23 @@ struct ResetButton: View {
 public struct preferencesListView: View {
     @Bindable var viewModel: SearchViewModel
     @Environment(\.modelContext) var modelContext
+
     
     public var body: some View {
         VStack{
+            HStack{
+                Text("Selected Preferences:")
+                    .padding(.top, 25)
+                    .padding(.leading, 12)
+                    .font(.headline).bold()
+                Spacer()
+            }
             HStack {
-                Text("Your selections show up here. Tap to remove them.")
+                Text("Tap to remove")
                     .font(.footnote)
                     .foregroundStyle(.gray)
                     .padding(.leading, 12)
-                    .padding(.top, 25)
+                    
                 Spacer()
             }
                 ScrollView(.horizontal) {
@@ -161,6 +171,7 @@ public struct preferencesListView: View {
                                     withAnimation(.snappy) {
                                         viewModel.preferredCount -= 1
                                         viewModel.preferredIngredients.removeAll(where: { $0 == preferredIngredient})
+                                
                                     }
                                 }
                         }
@@ -181,6 +192,7 @@ public struct preferencesListView: View {
                                 .onTapGesture {
                                     withAnimation(.snappy) {
                                         viewModel.unwantedIngredients.removeAll(where:{ $0 == unwantedIngredient })
+                                      
                                     }
                                 }
                         }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
@@ -171,6 +171,7 @@ public struct preferencesListView: View {
                                     withAnimation(.snappy) {
                                         viewModel.preferredCount -= 1
                                         viewModel.preferredIngredients.removeAll(where: { $0 == preferredIngredient})
+                                        viewModel.createMatchContainers()
                                 
                                     }
                                 }
@@ -192,7 +193,7 @@ public struct preferencesListView: View {
                                 .onTapGesture {
                                     withAnimation(.snappy) {
                                         viewModel.unwantedIngredients.removeAll(where:{ $0 == unwantedIngredient })
-                                      
+                                        viewModel.createMatchContainers()
                                     }
                                 }
                         }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
@@ -58,8 +58,7 @@ struct ThumbsUpOrDownIngredientSearchList: View {
                         .autocorrectionDisabled(true)
                         .onChange(of: viewModel.currentComponentSearchName, initial: true) { old, new in
                             viewModel.currentComponentSearchName = new
-                            viewModel.filteredIngredients = viewModel.matchAllIngredients(ingredients: ingredients)
-                            viewModel.filteredSubCategories = viewModel.matchAllSubCategories()
+                            viewModel.filteredIngredients = viewModel.matchAllIngredients(ingredients: ingredients.map({$0.name}), subCategories: viewModel.subCategoryStrings)
                         }
                     if !viewModel.currentComponentSearchName.isEmpty {
                         Button {
@@ -73,19 +72,12 @@ struct ThumbsUpOrDownIngredientSearchList: View {
                 }
             }
             if keyboardFocused {
+               
                 List {
-                    ForEach($viewModel.filteredSubCategories, id: \.self) { subCategory in
-                        PreferencesThumbsCellForSubCategories(viewModel: viewModel, subCategory: subCategory)
-                    }
-                    .listStyle(.plain)
-                    .listRowBackground(Color.black)
-                }
-                .scrollContentBackground(.hidden)
-                List {
-                    ForEach($viewModel.filteredIngredients, id: \.name) { ingredient in
-                        if !viewModel.subCategoryStrings.contains(ingredient.name.wrappedValue){
+                    ForEach($viewModel.filteredIngredients, id: \.self) { ingredient in
+                       
                             PreferencesThumbsCell(viewModel: viewModel, ingredient: ingredient)
-                        }
+                        
                     }
                     .listStyle(.plain)
                     .listRowBackground(Color.black)
@@ -172,15 +164,6 @@ public struct preferencesListView: View {
                                     }
                                 }
                         }
-                        ForEach(viewModel.preferredSubCategories, id: \.self) { preferredSubCategory in
-                            viewModel.viewModelTagView(preferredSubCategory, .green , "xmark")
-                                .onTapGesture {
-                                    withAnimation(.snappy) {
-                                        viewModel.preferredCount -= 1
-                                        viewModel.preferredSubCategories.removeAll(where: { $0 == preferredSubCategory})
-                                    }
-                                }
-                        }
                     }
                     .padding(.horizontal, 15)
                     .frame(height: 35)
@@ -198,14 +181,6 @@ public struct preferencesListView: View {
                                 .onTapGesture {
                                     withAnimation(.snappy) {
                                         viewModel.unwantedIngredients.removeAll(where:{ $0 == unwantedIngredient })
-                                    }
-                                }
-                        }
-                        ForEach(viewModel.unwantedSubCategories, id: \.self) { unwantedSubCategory in
-                            viewModel.viewModelTagView(unwantedSubCategory, .red, "xmark")
-                                .onTapGesture {
-                                    withAnimation(.snappy) {
-                                        viewModel.unwantedSubCategories.removeAll(where:{ $0 == unwantedSubCategory })
                                     }
                                 }
                         }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
@@ -171,7 +171,7 @@ public struct preferencesListView: View {
                                     withAnimation(.snappy) {
                                         viewModel.preferredCount -= 1
                                         viewModel.preferredIngredients.removeAll(where: { $0 == preferredIngredient})
-                                        viewModel.createMatchContainers()
+                                 
                                 
                                     }
                                 }
@@ -193,7 +193,7 @@ public struct preferencesListView: View {
                                 .onTapGesture {
                                     withAnimation(.snappy) {
                                         viewModel.unwantedIngredients.removeAll(where:{ $0 == unwantedIngredient })
-                                        viewModel.createMatchContainers()
+                                    
                                     }
                                 }
                         }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/BasicSearchViewWithDataQuery.swift
@@ -50,15 +50,16 @@ struct ThumbsUpOrDownIngredientSearchList: View {
     @FocusState var keyboardFocused: Bool
     
     var body: some View {
-        Section("Name") {
+        Section("Component Name:") {
             VStack{
                 HStack{
-                    TextField("Flavor or Ingredient", text: $viewModel.currentComponentSearchName)
+                    TextField("Flavor, Ingredient, Style, or Profile...", text: $viewModel.currentComponentSearchName)
                         .focused($keyboardFocused)
                         .autocorrectionDisabled(true)
                         .onChange(of: viewModel.currentComponentSearchName, initial: true) { old, new in
                             viewModel.currentComponentSearchName = new
                             viewModel.filteredIngredients = viewModel.matchAllIngredients(ingredients: ingredients)
+                            viewModel.filteredSubCategories = viewModel.matchAllSubCategories()
                         }
                     if !viewModel.currentComponentSearchName.isEmpty {
                         Button {
@@ -73,15 +74,21 @@ struct ThumbsUpOrDownIngredientSearchList: View {
             }
             if keyboardFocused {
                 List {
-                    ForEach($viewModel.filteredIngredients, id: \.name) { ingredient in
-                        
-                        PreferencesThumbsCell(viewModel: viewModel, ingredient: ingredient)
-                        
-                        
+                    ForEach($viewModel.filteredSubCategories, id: \.self) { subCategory in
+                        PreferencesThumbsCellForSubCategories(viewModel: viewModel, subCategory: subCategory)
                     }
                     .listStyle(.plain)
                     .listRowBackground(Color.black)
-                    
+                }
+                .scrollContentBackground(.hidden)
+                List {
+                    ForEach($viewModel.filteredIngredients, id: \.name) { ingredient in
+                        if !viewModel.subCategoryStrings.contains(ingredient.name.wrappedValue){
+                            PreferencesThumbsCell(viewModel: viewModel, ingredient: ingredient)
+                        }
+                    }
+                    .listStyle(.plain)
+                    .listRowBackground(Color.black)
                 }
                 .scrollContentBackground(.hidden)
             } else {
@@ -165,6 +172,15 @@ public struct preferencesListView: View {
                                     }
                                 }
                         }
+                        ForEach(viewModel.preferredSubCategories, id: \.self) { preferredSubCategory in
+                            viewModel.viewModelTagView(preferredSubCategory, .green , "xmark")
+                                .onTapGesture {
+                                    withAnimation(.snappy) {
+                                        viewModel.preferredCount -= 1
+                                        viewModel.preferredSubCategories.removeAll(where: { $0 == preferredSubCategory})
+                                    }
+                                }
+                        }
                     }
                     .padding(.horizontal, 15)
                     .frame(height: 35)
@@ -182,6 +198,14 @@ public struct preferencesListView: View {
                                 .onTapGesture {
                                     withAnimation(.snappy) {
                                         viewModel.unwantedIngredients.removeAll(where:{ $0 == unwantedIngredient })
+                                    }
+                                }
+                        }
+                        ForEach(viewModel.unwantedSubCategories, id: \.self) { unwantedSubCategory in
+                            viewModel.viewModelTagView(unwantedSubCategory, .red, "xmark")
+                                .onTapGesture {
+                                    withAnimation(.snappy) {
+                                        viewModel.unwantedSubCategories.removeAll(where:{ $0 == unwantedSubCategory })
                                     }
                                 }
                         }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/CocktailResultListDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/CocktailResultListDataQueries.swift
@@ -19,10 +19,12 @@ struct CocktailResultListDataQueries: View {
     @Query var minusFourMatchCocktails: [Cocktail]
 
     
-    init(preferredIngredients: [String], notPreferredIngredients: [String], passedViewModel: SearchViewModel) {
+    init(preferredIngredients: [String], preferredSubCategories: [String], notPreferredIngredients: [String], notPreferredSubCategories: [String], passedViewModel: SearchViewModel) {
         self.viewModel = passedViewModel
         let explicitPreferredCount = viewModel.preferredCount
    
+        
+        
         let matchesAllPreferredIngredients = #Expression<[Ingredient], Bool> { ingredients in
             ingredients.filter { ingredient in
                 preferredIngredients.contains(ingredient.ingredientBase.name)

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/CocktailResultListDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/CocktailResultListDataQueries.swift
@@ -14,8 +14,6 @@ struct CocktailResultListDataQueries: View {
     @Query var fullMatchCocktails: [Cocktail]
     @Query var minusOneMatchCocktails: [Cocktail]
     @Query var minusTwoMatchCocktails: [Cocktail]
-    @Query var minusThreeMatchCocktails: [Cocktail]
-    @Query var minusFourMatchCocktails: [Cocktail]
 
     
     init(preferredIngredients: [String], notPreferredIngredients: [String], passedViewModel: SearchViewModel) {
@@ -41,39 +39,25 @@ struct CocktailResultListDataQueries: View {
                 
             }.count == (explicitPreferredCount - 1)
         }
-       
-        
         let matchesAllButTwoPreferredIngredients = #Expression<[Ingredient], Bool> { ingredients in
             ingredients.filter { ingredient in
                 preferredIngredientsWithoutSubCategories.contains(ingredient.ingredientBase.name)
             }.count == (explicitPreferredCount - 2)
         }
-        let matchesAllButThreePreferredIngredients = #Expression<[Ingredient], Bool> { ingredients in
-            ingredients.filter { ingredient in
-                preferredIngredientsWithoutSubCategories.contains(ingredient.ingredientBase.name)
-            }.count == (explicitPreferredCount - 3)
-        }
-        let matchesAllButFourPreferredIngredients = #Expression<[Ingredient], Bool> { ingredients in
-            ingredients.filter { ingredient in
-                preferredIngredientsWithoutSubCategories.contains(ingredient.ingredientBase.name)
-            }.count == (explicitPreferredCount - 4)
-        }
+      
+        // Exclude all cocktails with unwanted ingredients
         let includesUnwantedIngredients = #Expression<[Ingredient], Bool> { ingredients in
             ingredients.filter { ingredient in
                 unwantedIngredientsWithoutSubCategories.contains(ingredient.ingredientBase.name)
             }.count > 0
         }
+        // Exclude all cocktails with ingredients from unwanted sub categories
         let includesUnwantedIngredientsFromSubCategories = #Expression<[Ingredient], Bool> { ingredients in
             ingredients.filter { ingredient in
                 unwantedIngredientsFromSubCategories.contains(ingredient.ingredientBase.name)
             }.count > 0
         }
         
-        let includesPreferredIngredientsFromSubCategories = #Expression<[Ingredient], Bool> { ingredients in
-            ingredients.filter { ingredient in
-                preferredIngredientsFromSubCategories.contains(ingredient.ingredientBase.name)
-            }.count > 0
-        }
         
         let fullMatchPredicate = #Predicate<Cocktail> { cocktail in
             matchesAllPreferredIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredientsFromSubCategories.evaluate(cocktail.spec)
@@ -84,18 +68,12 @@ struct CocktailResultListDataQueries: View {
         let minusTwoMatchPredicate = #Predicate<Cocktail> { cocktail in
             matchesAllButTwoPreferredIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredientsFromSubCategories.evaluate(cocktail.spec)
         }
-        let minusThreeMatchPredicate = #Predicate<Cocktail> { cocktail in
-            matchesAllButThreePreferredIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredientsFromSubCategories.evaluate(cocktail.spec)
-        }
-        let minusFourMatchPredicate = #Predicate<Cocktail> { cocktail in
-            matchesAllButFourPreferredIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredients.evaluate(cocktail.spec) && !includesUnwantedIngredientsFromSubCategories.evaluate(cocktail.spec)
-        }
+      
         
         _fullMatchCocktails = Query(filter: fullMatchPredicate, sort: \Cocktail.cocktailName)
         _minusOneMatchCocktails = Query(filter: minusOneMatchPredicate, sort: \Cocktail.cocktailName)
         _minusTwoMatchCocktails = Query(filter: minusTwoMatchPredicate, sort: \Cocktail.cocktailName)
-        _minusThreeMatchCocktails = Query(filter: minusThreeMatchPredicate, sort: \Cocktail.cocktailName)
-        _minusFourMatchCocktails = Query(filter: minusFourMatchPredicate, sort: \Cocktail.cocktailName)
+        
         
         
     }
@@ -186,7 +164,7 @@ struct CocktailResultListDataQueries: View {
                     
                     viewModel.sections.removeAll()
                     viewModel.sections = viewModel.createMatchContainers()
-                    viewModel.createResultsForSectionData(perfectMatch: fullMatchCocktails, minusOne: minusOneMatchCocktails, minusTwo: minusTwoMatchCocktails, minusThree: minusThreeMatchCocktails, minusFour: minusFourMatchCocktails)
+                    viewModel.createResultsForSectionData(perfectMatch: fullMatchCocktails, minusOne: minusOneMatchCocktails, minusTwo: minusTwoMatchCocktails)
                 }
                 viewModel.willLoadOnAppear = false
             }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
@@ -41,9 +41,7 @@ struct SearchResultsViewDataQueries: View {
             
             VStack(alignment: .leading) {
                 preferencesListView(viewModel: viewModel)
-                CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients,
-                                              notPreferredIngredients: viewModel.unwantedIngredients,
-                                              passedViewModel: viewModel)
+                CocktailResultListDataQueries(viewModel: viewModel)
                 .navigationBarBackButtonHidden(true)
             }
             .navigationBarTitleDisplayMode(.inline)

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
@@ -34,7 +34,7 @@ struct SearchResultsViewDataQueries: View {
         VStack(alignment: .leading) {
 
 //            preferencesListView(viewModel: viewModel)
-            CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients, notPreferredIngredients: viewModel.unwantedIngredients, passedViewModel: viewModel)
+            CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients, preferredSubCategories: viewModel.preferredSubCategories, notPreferredIngredients: viewModel.unwantedIngredients, notPreferredSubCategories: viewModel.unwantedSubCategories, passedViewModel: viewModel)
                 .navigationBarBackButtonHidden(true)
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
@@ -34,7 +34,7 @@ struct SearchResultsViewDataQueries: View {
         VStack(alignment: .leading) {
 
 //            preferencesListView(viewModel: viewModel)
-            CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients, preferredSubCategories: viewModel.preferredSubCategories, notPreferredIngredients: viewModel.unwantedIngredients, notPreferredSubCategories: viewModel.unwantedSubCategories, passedViewModel: viewModel)
+            CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients, notPreferredIngredients: viewModel.unwantedIngredients, passedViewModel: viewModel)
                 .navigationBarBackButtonHidden(true)
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchResultsViewDataQueries.swift
@@ -15,30 +15,41 @@ struct SearchResultsViewDataQueries: View {
 
     
     var body: some View {
-        HStack{
-            Button{
-                viewModel.onBasisSearchView = true
-                viewModel.willLoadOnAppear = true
-                dismiss()
-                
-            } label: {
-                Image(systemName: "chevron.backward")
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 9)
-                    .bold()
-                    .tint(.cyan)
+        NavigationStack{
+            HStack{
+                Button{
+                    viewModel.onBasisSearchView = true
+                    viewModel.willLoadOnAppear = true
+                    dismiss()
+                    
+                } label: {
+                    Image(systemName: "chevron.backward")
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 9)
+                        .bold()
+                        .tint(.cyan)
+                }
+                Spacer()
             }
-            Spacer()
-        }
-        VStack(alignment: .leading) {
-
-//            preferencesListView(viewModel: viewModel)
-            CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients, notPreferredIngredients: viewModel.unwantedIngredients, passedViewModel: viewModel)
+            HStack {
+                Text("Matched Cocktails")
+                    .font(.largeTitle).bold()
+                    .padding(EdgeInsets(top: 0, leading: 12, bottom: -7, trailing: 0))
+                Spacer()
+            }
+            
+            VStack(alignment: .leading) {
+                preferencesListView(viewModel: viewModel)
+                CocktailResultListDataQueries(preferredIngredients: viewModel.preferredIngredients,
+                                              notPreferredIngredients: viewModel.unwantedIngredients,
+                                              passedViewModel: viewModel)
                 .navigationBarBackButtonHidden(true)
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            
+            
         }
-        .navigationBarTitleDisplayMode(.inline)
-        
     }
     
     @ViewBuilder func SearchResultsTagView(_ tag: String, _ color: Color, _ icon: String) -> some View {
@@ -64,7 +75,7 @@ struct SearchResultsViewDataQueries: View {
 
 #Preview {
     let preview = PreviewContainer([Cocktail.self], isStoredInMemoryOnly: true)
-    return SearchResultsViewDataQueries(viewModel: SearchViewModel())
+    SearchResultsViewDataQueries(viewModel: SearchViewModel())
         .modelContainer(preview.container)
 }
 

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -28,7 +28,8 @@ final class SearchViewModel: ObservableObject {
     var willLoadOnAppear = true
     var onBasisSearchView: Bool = true
 
-
+    var cocktailsAndMissingIngredientsForMinusOne: [CocktailsAndMissingIngredients] = []
+    var cocktailsAndMissingIngredientsForMinusTwo: [CocktailsAndMissingIngredients] = []
 
     func clearData() {
         currentComponentSearchName = ""
@@ -83,54 +84,17 @@ final class SearchViewModel: ObservableObject {
         appendPreferredIngredients(for: Liqueur.self)
     }
     
-    func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail]) {
-        for section in sections {
-            if section.matched == preferredCount {
-                for cocktail in perfectMatch {
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: [], cocktail: cocktail))
-                }
-            }
-            if section.matched == (preferredCount - 1) {
-                for cocktail in minusOne {
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
-            if section.matched == (preferredCount - 2) {
-                for cocktail in minusTwo{
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
+    
+    func findCocktailsAndMissingIngredients(cocktails: [Cocktail]) -> [CocktailsAndMissingIngredients] {
+       
+        var cocktailsAndMissingIngredients: [CocktailsAndMissingIngredients] = []
+        for cocktail in cocktails {
+            cocktailsAndMissingIngredients.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
         }
+       return cocktailsAndMissingIngredients
     }
     
-    func perfectMatch(perfectMatch: [Cocktail]) {
-       
-        for section in sections {
-            if section.sectionsPreferredCount == preferredCount {
-                for cocktail in perfectMatch {
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: [], cocktail: cocktail))
-                    
-                }
-            }
-        }
-    }
-    func minusOneCocktailsAndMissingIngredients(minusOne: [Cocktail]) -> [CocktailsAndMissingIngredients] {
-       
-        var minusOneSectionCocktails: [CocktailsAndMissingIngredients] = []
-        for cocktail in minusOne {
-            minusOneSectionCocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-        }
-       return minusOneSectionCocktails
-    }
-    func minusTwo(minusTwo: [Cocktail]) {
-        for section in sections {
-            if section.sectionsPreferredCount == (preferredCount - 2) {
-                for cocktail in minusTwo{
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
-        }
-    }
+    
     func combinedPreferredIngredientsAndSubCategories() {
         
     }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -16,7 +16,10 @@ final class SearchViewModel: ObservableObject {
     
     var currentComponentSearchName: String = ""
     var filteredIngredients: [IngredientBase] = []
-    
+    var filteredSubCategories: [SubCategories] = []
+    var subCategoryStrings: [String] = SubCategories.allCases.map({$0.rawValue})
+    var unwantedSubCategories: [String] = []
+    var preferredSubCategories: [String] = []
     var unwantedIngredients: [String] = []
     var preferredIngredients: [String] = []
     
@@ -132,6 +135,7 @@ final class SearchViewModel: ObservableObject {
              return [] // Return all ingredients if search text is empty
          }
         let lowercasedSearchText = currentComponentSearchName.lowercased()
+        
         return ingredients.filter { $0.name.lowercased().contains(lowercasedSearchText) }
             .sorted { lhs, rhs in
                 let lhsLowercased = lhs.name.lowercased()
@@ -147,6 +151,36 @@ final class SearchViewModel: ObservableObject {
                 // if two ingredients start with the same search text, prioritize the shortest one
                 if lhsStartsWith && rhsStartsWith {
                     return lhs.name.count < rhs.name.count
+                }
+                // If neither starts with the search text, prioritize the one with the search text appearing first in the word
+                let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())
+                let rhsRange = rhsLowercased.range(of: currentComponentSearchName.lowercased())
+                let matchedArray = (lhsRange?.lowerBound ?? lhsLowercased.endIndex) < (rhsRange?.lowerBound ?? rhsLowercased.endIndex)
+                return matchedArray
+            }
+    }
+    func matchAllSubCategories() -> [SubCategories] {
+        
+        guard !currentComponentSearchName.isEmpty else {
+             return [] // Return all ingredients if search text is empty
+         }
+        let lowercasedSearchText = currentComponentSearchName.lowercased()
+        
+        return SubCategories.allCases.filter { $0.rawValue.lowercased().contains(lowercasedSearchText) }
+            .sorted { lhs, rhs in
+                let lhsLowercased = lhs.rawValue.lowercased()
+                let rhsLowercased = rhs.rawValue.lowercased()
+                // prioritize ingredients that start with the search text
+                let lhsStartsWith = lhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
+                let rhsStartsWith = rhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
+                if lhsStartsWith && !rhsStartsWith {
+                    return true
+                } else if !lhsStartsWith && rhsStartsWith {
+                    return false
+                }
+                // if two ingredients start with the same search text, prioritize the shortest one
+                if lhsStartsWith && rhsStartsWith {
+                    return lhs.rawValue.count < rhs.rawValue.count
                 }
                 // If neither starts with the search text, prioritize the one with the search text appearing first in the word
                 let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -14,7 +14,7 @@ import SwiftData
 @Observable
 final class SearchViewModel: ObservableObject {
     
-    
+    var nonmatchSearchPreference: String = "none"
     var currentComponentSearchName: String = ""
     var filteredIngredients: [String] = []
     var subCategoryStrings: [String] = SubCategories.allCases.map({$0.rawValue})
@@ -102,6 +102,7 @@ final class SearchViewModel: ObservableObject {
             }
         }
     }
+    
     func perfectMatch(perfectMatch: [Cocktail]) {
        
         for section in sections {
@@ -113,14 +114,13 @@ final class SearchViewModel: ObservableObject {
             }
         }
     }
-    func minusOne(minusOne: [Cocktail]) {
-        for section in sections {
-            if section.sectionsPreferredCount == (preferredCount - 1) {
-                for cocktail in minusOne {
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
+    func minusOneCocktailsAndMissingIngredients(minusOne: [Cocktail]) -> [CocktailsAndMissingIngredients] {
+       
+        var minusOneSectionCocktails: [CocktailsAndMissingIngredients] = []
+        for cocktail in minusOne {
+            minusOneSectionCocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
         }
+       return minusOneSectionCocktails
     }
     func minusTwo(minusTwo: [Cocktail]) {
         for section in sections {
@@ -131,13 +131,15 @@ final class SearchViewModel: ObservableObject {
             }
         }
     }
-    func createMatchContainers() -> [ResultViewSectionData] {
-            var dataShells = [ResultViewSectionData]()
-            for i in 0...Int(preferredCount / 2) {
-                let numberOfMatches = (preferredCount - i)
-                dataShells.append(ResultViewSectionData(count: preferredCount, matched: numberOfMatches, cocktails: []))
-            }
-            return dataShells
+    func combinedPreferredIngredientsAndSubCategories() {
+        
+    }
+    func createMatchContainers()  {
+        sections = []
+        for i in 0...Int(preferredCount / 2) {
+            let numberOfMatches = (preferredCount - i)
+            sections.append(ResultViewSectionData(count: preferredCount, matched: numberOfMatches, cocktails: []))
+        }
     }
     
     func findMissingIngredients(cocktail: Cocktail) -> [String] {

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -21,6 +21,7 @@ final class SearchViewModel: ObservableObject {
     var unwantedIngredients: [String] = []
     var preferredIngredients: [String] = []
     var unwantedIngredientsFromSubCategories: [String] = []
+    var preferredIngredientsFromSubCategories: [String] = []
     var isLoading = true
     var preferredCount = 0
     var sections: [ResultViewSectionData] = []
@@ -33,14 +34,17 @@ final class SearchViewModel: ObservableObject {
         currentComponentSearchName = ""
         unwantedIngredients = []
         unwantedIngredientsFromSubCategories = []
+        preferredIngredientsFromSubCategories = []
         preferredIngredients = []
         sections.removeAll()
         preferredCount = 0
     }
 
-    func findUnwantedIngredientNamesForCorrespondingSubCategories() {
+    func findIngredientNamesForCorrespondingSubCategories() {
         unwantedIngredientsFromSubCategories = []
+        preferredIngredientsFromSubCategories = []
         let unwantedSubCategories = unwantedIngredients.filter { subCategoryStrings.contains($0) }
+        let preferredSubCategories = preferredIngredients.filter { subCategoryStrings.contains($0) }
         
         func appendUnwantedIngredients<T: CaseIterable & RawRepresentable>(for type: T.Type) where T.AllCases: RandomAccessCollection, T.RawValue == String {
             for booze in type.allCases {
@@ -48,6 +52,15 @@ final class SearchViewModel: ObservableObject {
                    boozeTags.map({ $0.name }).contains(where: { unwantedSubCategories.contains($0) }),
                    !unwantedIngredients.contains(booze.rawValue) {
                     unwantedIngredientsFromSubCategories.append(booze.rawValue)
+                }
+            }
+        }
+        func appendPreferredIngredients<T: CaseIterable & RawRepresentable>(for type: T.Type) where T.AllCases: RandomAccessCollection, T.RawValue == String {
+            for booze in type.allCases {
+                if let boozeTags = (booze as? BoozeTagsProtocol)?.tags.booze,
+                   boozeTags.map({ $0.name }).contains(where: { preferredSubCategories.contains($0) }),
+                   !preferredIngredients.contains(booze.rawValue) {
+                    preferredIngredientsFromSubCategories.append(booze.rawValue)
                 }
             }
         }
@@ -59,6 +72,15 @@ final class SearchViewModel: ObservableObject {
         appendUnwantedIngredients(for: Whiskey.self)
         appendUnwantedIngredients(for: Wine.self)
         appendUnwantedIngredients(for: Liqueur.self)
+        
+        appendPreferredIngredients(for: Agave.self)
+        appendPreferredIngredients(for: Brandy.self)
+        appendPreferredIngredients(for: Gin.self)
+        appendPreferredIngredients(for: Rum.self)
+        appendPreferredIngredients(for: Vodka.self)
+        appendPreferredIngredients(for: Whiskey.self)
+        appendPreferredIngredients(for: Wine.self)
+        appendPreferredIngredients(for: Liqueur.self)
     }
     
     func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail], minusThree: [Cocktail], minusFour: [Cocktail]) {

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -83,7 +83,7 @@ final class SearchViewModel: ObservableObject {
         appendPreferredIngredients(for: Liqueur.self)
     }
     
-    func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail], minusThree: [Cocktail], minusFour: [Cocktail]) {
+    func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail]) {
         for section in sections {
             if section.matched == preferredCount {
                 for cocktail in perfectMatch {
@@ -97,16 +97,6 @@ final class SearchViewModel: ObservableObject {
             }
             if section.matched == (preferredCount - 2) {
                 for cocktail in minusTwo{
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
-            if section.matched == (preferredCount - 3) {
-                for cocktail in minusThree{
-                    section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-                }
-            }
-            if section.matched == (preferredCount - 4) {
-                for cocktail in minusThree{
                     section.cocktails.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
                 }
             }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -10,6 +10,7 @@ import Observation
 import SwiftData
 
 
+
 @Observable
 final class SearchViewModel: ObservableObject {
     
@@ -19,111 +20,46 @@ final class SearchViewModel: ObservableObject {
     var subCategoryStrings: [String] = SubCategories.allCases.map({$0.rawValue})
     var unwantedIngredients: [String] = []
     var preferredIngredients: [String] = []
-    
+    var unwantedIngredientsFromSubCategories: [String] = []
     var isLoading = true
     var preferredCount = 0
     var sections: [ResultViewSectionData] = []
     var willLoadOnAppear = true
     var onBasisSearchView: Bool = true
 
+
+
     func clearData() {
         currentComponentSearchName = ""
         unwantedIngredients = []
+        unwantedIngredientsFromSubCategories = []
         preferredIngredients = []
         sections.removeAll()
         preferredCount = 0
     }
 
-//    func findUnwantedIngredientNamesForCorrespondingSubCategories()  {
-//        
-//        for category in unwantedSubCategories {
-//           
-//            for booze in Agave.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Brandy.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Gin.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Rum.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Vodka.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Whiskey.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in FortifiedWine.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Bitters.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//            for booze in Amaro.allCases {
-//                if let boozeTags = booze.tags.booze {
-//                    for boozeTag in boozeTags {
-//                        if boozeTag.name == category {
-//                            unwantedIngredients.append(booze.rawValue)
-//                        }
-//                    }
-//                }
-//            }
-//        }
-//        for ingredient in unwantedIngredients {
-//            print(ingredient)
-//        }
-//    }
+    func findUnwantedIngredientNamesForCorrespondingSubCategories() {
+        unwantedIngredientsFromSubCategories = []
+        let unwantedSubCategories = unwantedIngredients.filter { subCategoryStrings.contains($0) }
+        
+        func appendUnwantedIngredients<T: CaseIterable & RawRepresentable>(for type: T.Type) where T.AllCases: RandomAccessCollection, T.RawValue == String {
+            for booze in type.allCases {
+                if let boozeTags = (booze as? BoozeTagsProtocol)?.tags.booze,
+                   boozeTags.map({ $0.name }).contains(where: { unwantedSubCategories.contains($0) }),
+                   !unwantedIngredients.contains(booze.rawValue) {
+                    unwantedIngredientsFromSubCategories.append(booze.rawValue)
+                }
+            }
+        }
+        appendUnwantedIngredients(for: Agave.self)
+        appendUnwantedIngredients(for: Brandy.self)
+        appendUnwantedIngredients(for: Gin.self)
+        appendUnwantedIngredients(for: Rum.self)
+        appendUnwantedIngredients(for: Vodka.self)
+        appendUnwantedIngredients(for: Whiskey.self)
+        appendUnwantedIngredients(for: Wine.self)
+        appendUnwantedIngredients(for: Liqueur.self)
+    }
     
     func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail], minusThree: [Cocktail], minusFour: [Cocktail]) {
         for section in sections {
@@ -217,7 +153,7 @@ final class SearchViewModel: ObservableObject {
         }
     }
 
-    func matchAllIngredients(ingredients: [String], subCategories: [String]) -> [String] {
+    func matchAllIngredientsAndSubcategories(ingredients: [String], subCategories: [String]) -> [String] {
         
         guard !currentComponentSearchName.isEmpty else {
              return [] // Return all ingredients if search text is empty
@@ -248,34 +184,10 @@ final class SearchViewModel: ObservableObject {
                 return matchedArray
             }
     }
-//    func matchAllSubCategories() -> [String] {
-//        
-//        guard !currentComponentSearchName.isEmpty else {
-//             return [] // Return all ingredients if search text is empty
-//         }
-//        let lowercasedSearchText = currentComponentSearchName.lowercased()
-//        
-//        return SubCategories.allCases.filter { $0.rawValue.lowercased().contains(lowercasedSearchText) }
-//            .sorted { lhs, rhs in
-//                let lhsLowercased = lhs.rawValue.lowercased()
-//                let rhsLowercased = rhs.rawValue.lowercased()
-//                // prioritize ingredients that start with the search text
-//                let lhsStartsWith = lhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
-//                let rhsStartsWith = rhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
-//                if lhsStartsWith && !rhsStartsWith {
-//                    return true
-//                } else if !lhsStartsWith && rhsStartsWith {
-//                    return false
-//                }
-//                // if two ingredients start with the same search text, prioritize the shortest one
-//                if lhsStartsWith && rhsStartsWith {
-//                    return lhs.rawValue.count < rhs.rawValue.count
-//                }
-//                // If neither starts with the search text, prioritize the one with the search text appearing first in the word
-//                let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())
-//                let rhsRange = rhsLowercased.range(of: currentComponentSearchName.lowercased())
-//                let matchedArray = (lhsRange?.lowerBound ?? lhsLowercased.endIndex) < (rhsRange?.lowerBound ?? rhsLowercased.endIndex)
-//                return matchedArray
-//            }
-//    }
+
+}
+
+
+class AppStateRefresh: ObservableObject {
+    @Published var refreshCocktailList = false
 }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -15,11 +15,8 @@ final class SearchViewModel: ObservableObject {
     
     
     var currentComponentSearchName: String = ""
-    var filteredIngredients: [IngredientBase] = []
-    var filteredSubCategories: [SubCategories] = []
+    var filteredIngredients: [String] = []
     var subCategoryStrings: [String] = SubCategories.allCases.map({$0.rawValue})
-    var unwantedSubCategories: [String] = []
-    var preferredSubCategories: [String] = []
     var unwantedIngredients: [String] = []
     var preferredIngredients: [String] = []
     
@@ -37,6 +34,97 @@ final class SearchViewModel: ObservableObject {
         preferredCount = 0
     }
 
+//    func findUnwantedIngredientNamesForCorrespondingSubCategories()  {
+//        
+//        for category in unwantedSubCategories {
+//           
+//            for booze in Agave.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Brandy.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Gin.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Rum.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Vodka.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Whiskey.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in FortifiedWine.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Bitters.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//            for booze in Amaro.allCases {
+//                if let boozeTags = booze.tags.booze {
+//                    for boozeTag in boozeTags {
+//                        if boozeTag.name == category {
+//                            unwantedIngredients.append(booze.rawValue)
+//                        }
+//                    }
+//                }
+//            }
+//        }
+//        for ingredient in unwantedIngredients {
+//            print(ingredient)
+//        }
+//    }
+    
     func createResultsForSectionData(perfectMatch: [Cocktail], minusOne: [Cocktail], minusTwo: [Cocktail], minusThree: [Cocktail], minusFour: [Cocktail]) {
         for section in sections {
             if section.matched == preferredCount {
@@ -129,17 +217,18 @@ final class SearchViewModel: ObservableObject {
         }
     }
 
-    func matchAllIngredients(ingredients: [IngredientBase]) -> [IngredientBase] {
+    func matchAllIngredients(ingredients: [String], subCategories: [String]) -> [String] {
         
         guard !currentComponentSearchName.isEmpty else {
              return [] // Return all ingredients if search text is empty
          }
         let lowercasedSearchText = currentComponentSearchName.lowercased()
-        
-        return ingredients.filter { $0.name.lowercased().contains(lowercasedSearchText) }
+        let combinedArrays = ingredients + subCategories
+        let combinedArraysWithoutDuplicates = Array(Set(combinedArrays))
+        return combinedArraysWithoutDuplicates.filter { $0.lowercased().contains(lowercasedSearchText) }
             .sorted { lhs, rhs in
-                let lhsLowercased = lhs.name.lowercased()
-                let rhsLowercased = rhs.name.lowercased()
+                let lhsLowercased = lhs.lowercased()
+                let rhsLowercased = rhs.lowercased()
                 // prioritize ingredients that start with the search text
                 let lhsStartsWith = lhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
                 let rhsStartsWith = rhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
@@ -150,7 +239,7 @@ final class SearchViewModel: ObservableObject {
                 }
                 // if two ingredients start with the same search text, prioritize the shortest one
                 if lhsStartsWith && rhsStartsWith {
-                    return lhs.name.count < rhs.name.count
+                    return lhs.count < rhs.count
                 }
                 // If neither starts with the search text, prioritize the one with the search text appearing first in the word
                 let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())
@@ -159,34 +248,34 @@ final class SearchViewModel: ObservableObject {
                 return matchedArray
             }
     }
-    func matchAllSubCategories() -> [SubCategories] {
-        
-        guard !currentComponentSearchName.isEmpty else {
-             return [] // Return all ingredients if search text is empty
-         }
-        let lowercasedSearchText = currentComponentSearchName.lowercased()
-        
-        return SubCategories.allCases.filter { $0.rawValue.lowercased().contains(lowercasedSearchText) }
-            .sorted { lhs, rhs in
-                let lhsLowercased = lhs.rawValue.lowercased()
-                let rhsLowercased = rhs.rawValue.lowercased()
-                // prioritize ingredients that start with the search text
-                let lhsStartsWith = lhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
-                let rhsStartsWith = rhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
-                if lhsStartsWith && !rhsStartsWith {
-                    return true
-                } else if !lhsStartsWith && rhsStartsWith {
-                    return false
-                }
-                // if two ingredients start with the same search text, prioritize the shortest one
-                if lhsStartsWith && rhsStartsWith {
-                    return lhs.rawValue.count < rhs.rawValue.count
-                }
-                // If neither starts with the search text, prioritize the one with the search text appearing first in the word
-                let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())
-                let rhsRange = rhsLowercased.range(of: currentComponentSearchName.lowercased())
-                let matchedArray = (lhsRange?.lowerBound ?? lhsLowercased.endIndex) < (rhsRange?.lowerBound ?? rhsLowercased.endIndex)
-                return matchedArray
-            }
-    }
+//    func matchAllSubCategories() -> [String] {
+//        
+//        guard !currentComponentSearchName.isEmpty else {
+//             return [] // Return all ingredients if search text is empty
+//         }
+//        let lowercasedSearchText = currentComponentSearchName.lowercased()
+//        
+//        return SubCategories.allCases.filter { $0.rawValue.lowercased().contains(lowercasedSearchText) }
+//            .sorted { lhs, rhs in
+//                let lhsLowercased = lhs.rawValue.lowercased()
+//                let rhsLowercased = rhs.rawValue.lowercased()
+//                // prioritize ingredients that start with the search text
+//                let lhsStartsWith = lhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
+//                let rhsStartsWith = rhsLowercased.hasPrefix(currentComponentSearchName.lowercased())
+//                if lhsStartsWith && !rhsStartsWith {
+//                    return true
+//                } else if !lhsStartsWith && rhsStartsWith {
+//                    return false
+//                }
+//                // if two ingredients start with the same search text, prioritize the shortest one
+//                if lhsStartsWith && rhsStartsWith {
+//                    return lhs.rawValue.count < rhs.rawValue.count
+//                }
+//                // If neither starts with the search text, prioritize the one with the search text appearing first in the word
+//                let lhsRange = lhsLowercased.range(of: currentComponentSearchName.lowercased())
+//                let rhsRange = rhsLowercased.range(of: currentComponentSearchName.lowercased())
+//                let matchedArray = (lhsRange?.lowerBound ?? lhsLowercased.endIndex) < (rhsRange?.lowerBound ?? rhsLowercased.endIndex)
+//                return matchedArray
+//            }
+//    }
 }

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SearchViewModel.swift
@@ -84,16 +84,7 @@ final class SearchViewModel: ObservableObject {
         appendPreferredIngredients(for: Liqueur.self)
     }
     
-    
-    func findCocktailsAndMissingIngredients(cocktails: [Cocktail]) -> [CocktailsAndMissingIngredients] {
-       
-        var cocktailsAndMissingIngredients: [CocktailsAndMissingIngredients] = []
-        for cocktail in cocktails {
-            cocktailsAndMissingIngredients.append(CocktailsAndMissingIngredients(missingIngredients: findMissingIngredients(cocktail: cocktail), cocktail: cocktail))
-        }
-       return cocktailsAndMissingIngredients
-    }
-    
+
     
     func combinedPreferredIngredientsAndSubCategories() {
         
@@ -106,9 +97,7 @@ final class SearchViewModel: ObservableObject {
         }
     }
     
-    func findMissingIngredients(cocktail: Cocktail) -> [String] {
-        preferredIngredients.filter({ !cocktail.spec.map({ $0.ingredientBase.name }).contains($0) })
-    }
+
     
     @ViewBuilder
     func viewModelTagView(_ tag: String, _ color: Color, _ icon: String) -> some View {

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SubViews/PreferencesThumbsCell.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SubViews/PreferencesThumbsCell.swift
@@ -54,3 +54,46 @@ struct PreferencesThumbsCell: View {
     @Previewable @State var mockIngredient = IngredientBase(name: "Test", category: Category.agaves, prep: nil)
     PreferencesThumbsCell(viewModel: SearchViewModel(), ingredient: $mockIngredient)
 }
+
+struct PreferencesThumbsCellForSubCategories: View {
+   
+    @Bindable var viewModel: SearchViewModel
+    @Binding var subCategory: SubCategories
+    
+    var body: some View {
+        HStack{
+            Text(subCategory.rawValue)
+            Spacer()
+            Image(systemName:viewModel.preferredSubCategories.contains(subCategory.rawValue) ? "hand.thumbsup.fill" : "hand.thumbsup")
+                .foregroundStyle(viewModel.preferredSubCategories.contains(subCategory.rawValue) ? .brandPrimaryGreen : .white)
+                .onTapGesture {
+                    if !viewModel.preferredSubCategories.contains(subCategory.rawValue) {
+                        viewModel.preferredSubCategories.append(subCategory.rawValue)
+                        viewModel.preferredCount += 1
+                        if viewModel.unwantedSubCategories.contains(subCategory.rawValue){
+                            viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+                        }
+                    } else {
+                        viewModel.preferredIngredients.removeAll(where: {$0 == subCategory.rawValue})
+                        viewModel.preferredCount -= 1
+                    }
+                }
+                .font(.system(size: 20))
+            Image(systemName:viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+                .foregroundStyle(viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? .brandPrimaryRed : .white)
+                .onTapGesture {
+                    if !viewModel.unwantedSubCategories.contains(subCategory.rawValue) {
+                        viewModel.unwantedSubCategories.append(subCategory.rawValue)
+                        if viewModel.preferredSubCategories.contains(subCategory.rawValue) {
+                            viewModel.preferredSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+                            viewModel.preferredCount -= 1
+                        }
+                    } else {
+                        viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+                    }
+                }
+                .padding(.horizontal, 10)
+                .font(.system(size: 20))
+        }
+    }
+}

--- a/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SubViews/PreferencesThumbsCell.swift
+++ b/MetaCocktailsSwiftData/Views/SearchViewWithDataQueries/SubViews/PreferencesThumbsCell.swift
@@ -10,38 +10,38 @@ import SwiftUI
 struct PreferencesThumbsCell: View {
    
     @Bindable var viewModel: SearchViewModel
-    @Binding var ingredient: IngredientBase
+    @Binding var ingredient: String
     
     var body: some View {
         HStack{
-            Text(ingredient.name)
+            Text(ingredient)
             Spacer()
-            Image(systemName:viewModel.preferredIngredients.contains(ingredient.name) ? "hand.thumbsup.fill" : "hand.thumbsup")
-                .foregroundStyle(viewModel.preferredIngredients.contains(ingredient.name) ? .brandPrimaryGreen : .white)
+            Image(systemName:viewModel.preferredIngredients.contains(ingredient)  ? "hand.thumbsup.fill" : "hand.thumbsup")
+                .foregroundStyle(viewModel.preferredIngredients.contains(ingredient)  ? .brandPrimaryGreen : .white)
                 .onTapGesture {
-                    if !viewModel.preferredIngredients.contains(ingredient.name) {
-                        viewModel.preferredIngredients.append(ingredient.name)
+                    if !viewModel.preferredIngredients.contains(ingredient) {
+                        viewModel.preferredIngredients.append(ingredient)
                         viewModel.preferredCount += 1
-                        if viewModel.unwantedIngredients.contains(ingredient.name){
-                            viewModel.unwantedIngredients.removeAll(where: {$0 == ingredient.name})
+                        if viewModel.unwantedIngredients.contains(ingredient){
+                            viewModel.unwantedIngredients.removeAll(where: {$0 == ingredient})
                         }
                     } else {
-                        viewModel.preferredIngredients.removeAll(where: {$0 == ingredient.name})
+                        viewModel.preferredIngredients.removeAll(where: {$0 == ingredient})
                         viewModel.preferredCount -= 1
                     }
                 }
                 .font(.system(size: 20))
-            Image(systemName:viewModel.unwantedIngredients.contains(ingredient.name) ? "hand.thumbsdown.fill" : "hand.thumbsdown")
-                .foregroundStyle(viewModel.unwantedIngredients.contains(ingredient.name) ? .brandPrimaryRed : .white)
+            Image(systemName:viewModel.unwantedIngredients.contains(ingredient)  ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+                .foregroundStyle(viewModel.unwantedIngredients.contains(ingredient)  ? .brandPrimaryRed : .white)
                 .onTapGesture {
-                    if !viewModel.unwantedIngredients.contains(ingredient.name) {
-                        viewModel.unwantedIngredients.append(ingredient.name)
-                        if viewModel.preferredIngredients.contains(ingredient.name) {
-                            viewModel.preferredIngredients.removeAll(where: {$0 == ingredient.name})
+                    if !viewModel.unwantedIngredients.contains(ingredient) {
+                        viewModel.unwantedIngredients.append(ingredient)
+                        if viewModel.preferredIngredients.contains(ingredient) {
+                            viewModel.preferredIngredients.removeAll(where: {$0 == ingredient})
                             viewModel.preferredCount -= 1
                         }
                     } else {
-                        viewModel.unwantedIngredients.removeAll(where: {$0 == ingredient.name})
+                        viewModel.unwantedIngredients.removeAll(where: {$0 == ingredient})
                     }
                 }
                 .padding(.horizontal, 10)
@@ -51,49 +51,49 @@ struct PreferencesThumbsCell: View {
 }
 
 #Preview {
-    @Previewable @State var mockIngredient = IngredientBase(name: "Test", category: Category.agaves, prep: nil)
+    @Previewable @State var mockIngredient = "Fun Ingredient"
     PreferencesThumbsCell(viewModel: SearchViewModel(), ingredient: $mockIngredient)
 }
 
-struct PreferencesThumbsCellForSubCategories: View {
-   
-    @Bindable var viewModel: SearchViewModel
-    @Binding var subCategory: SubCategories
-    
-    var body: some View {
-        HStack{
-            Text(subCategory.rawValue)
-            Spacer()
-            Image(systemName:viewModel.preferredSubCategories.contains(subCategory.rawValue) ? "hand.thumbsup.fill" : "hand.thumbsup")
-                .foregroundStyle(viewModel.preferredSubCategories.contains(subCategory.rawValue) ? .brandPrimaryGreen : .white)
-                .onTapGesture {
-                    if !viewModel.preferredSubCategories.contains(subCategory.rawValue) {
-                        viewModel.preferredSubCategories.append(subCategory.rawValue)
-                        viewModel.preferredCount += 1
-                        if viewModel.unwantedSubCategories.contains(subCategory.rawValue){
-                            viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
-                        }
-                    } else {
-                        viewModel.preferredIngredients.removeAll(where: {$0 == subCategory.rawValue})
-                        viewModel.preferredCount -= 1
-                    }
-                }
-                .font(.system(size: 20))
-            Image(systemName:viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? "hand.thumbsdown.fill" : "hand.thumbsdown")
-                .foregroundStyle(viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? .brandPrimaryRed : .white)
-                .onTapGesture {
-                    if !viewModel.unwantedSubCategories.contains(subCategory.rawValue) {
-                        viewModel.unwantedSubCategories.append(subCategory.rawValue)
-                        if viewModel.preferredSubCategories.contains(subCategory.rawValue) {
-                            viewModel.preferredSubCategories.removeAll(where: {$0 == subCategory.rawValue})
-                            viewModel.preferredCount -= 1
-                        }
-                    } else {
-                        viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
-                    }
-                }
-                .padding(.horizontal, 10)
-                .font(.system(size: 20))
-        }
-    }
-}
+//struct PreferencesThumbsCellForSubCategories: View {
+//   
+//    @Bindable var viewModel: SearchViewModel
+//    @Binding var subCategory: SubCategories
+//    
+//    var body: some View {
+//        HStack{
+//            Text(subCategory.rawValue)
+//            Spacer()
+//            Image(systemName:viewModel.preferredSubCategories.contains(subCategory.rawValue) ? "hand.thumbsup.fill" : "hand.thumbsup")
+//                .foregroundStyle(viewModel.preferredSubCategories.contains(subCategory.rawValue) ? .brandPrimaryGreen : .white)
+//                .onTapGesture {
+//                    if !viewModel.preferredSubCategories.contains(subCategory.rawValue) {
+//                        viewModel.preferredSubCategories.append(subCategory.rawValue)
+//                        viewModel.preferredCount += 1
+//                        if viewModel.unwantedSubCategories.contains(subCategory.rawValue){
+//                            viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+//                        }
+//                    } else {
+//                        viewModel.preferredIngredients.removeAll(where: {$0 == subCategory.rawValue})
+//                        viewModel.preferredCount -= 1
+//                    }
+//                }
+//                .font(.system(size: 20))
+//            Image(systemName:viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+//                .foregroundStyle(viewModel.unwantedSubCategories.contains(subCategory.rawValue) ? .brandPrimaryRed : .white)
+//                .onTapGesture {
+//                    if !viewModel.unwantedSubCategories.contains(subCategory.rawValue) {
+//                        viewModel.unwantedSubCategories.append(subCategory.rawValue)
+//                        if viewModel.preferredSubCategories.contains(subCategory.rawValue) {
+//                            viewModel.preferredSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+//                            viewModel.preferredCount -= 1
+//                        }
+//                    } else {
+//                        viewModel.unwantedSubCategories.removeAll(where: {$0 == subCategory.rawValue})
+//                    }
+//                }
+//                .padding(.horizontal, 10)
+//                .font(.system(size: 20))
+//        }
+//    }
+//}


### PR DESCRIPTION
***Queries are not connected yet.

I want to make sure I'm searching correctly before I move on to the next step. 

The subcategories only show up in the filtered list on the initial search view. 

first I made arrays on SearchViewModel for preferredSubCategories and unwantedSubCategories as well as an array of subCategoryStrings to check against.
![Screenshot 2024-07-17 at 8 41 55 PM](https://github.com/user-attachments/assets/49a853e3-3ead-4a84-8c0e-c275fce17906)

then i made a function on the model to filter subCategories:
![Screenshot 2024-07-17 at 8 43 04 PM](https://github.com/user-attachments/assets/eaab8a7b-40ca-45c7-af02-ca47c874263d)

Then I made a PreferencesThumbsCellForSubCategories:
![Screenshot 2024-07-17 at 8 44 05 PM](https://github.com/user-attachments/assets/db474a90-9aca-4b32-85a2-464ba5142b18)

In ThumbsUpOrDownIngredientSearchList I stacked the subCategories above the filteredIngredientsList so that they would show up first because they are the more common search terms.
In the filteredIngredients list, I check to see if !viewModel.subCategoryStrings.contains(ingredient.name.wrappedValue) before adding PreferencesThumbsCell(viewModel: viewModel, ingredient: ingredient) so that the same term doesn't show up twice in the search.
![Screenshot 2024-07-17 at 8 46 27 PM](https://github.com/user-attachments/assets/2a9fb58f-ca5a-48d3-bf28-7e89e350dc0b)

Now we have a list of subCategories and ingredients to search with. The question now is how to work the expressions so that we filter cocktails correctly. 