### PR TITLE
Added comments to explain the optimization.

### DIFF
--- a/MetaCocktailsSwiftData/Views/Search View/IngredientSearchView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/IngredientSearchView.swift
@@ -127,7 +127,9 @@ struct ThumbsUpOrDownIngredientSearchListView: View {
                         .focused($keyboardFocused)
                         .autocorrectionDisabled(true)
                         .onChange(of: viewModel.currentComponentSearchName) { _, newValue in
+                           
                             viewModel.updateSearch(newValue)
+                            
                         }
                     if !viewModel.currentComponentSearchName.isEmpty {
                         Button {

--- a/MetaCocktailsSwiftData/Views/Search View/IngredientSearchView.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/IngredientSearchView.swift
@@ -127,9 +127,7 @@ struct ThumbsUpOrDownIngredientSearchListView: View {
                         .focused($keyboardFocused)
                         .autocorrectionDisabled(true)
                         .onChange(of: viewModel.currentComponentSearchName) { _, newValue in
-                           
                             viewModel.updateSearch(newValue)
-                            
                         }
                     if !viewModel.currentComponentSearchName.isEmpty {
                         Button {

--- a/MetaCocktailsSwiftData/Views/Search View/SearchViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SearchViewModel.swift
@@ -328,17 +328,21 @@ final class SearchViewModel: ObservableObject {
         searchSubject.send(searchText)
     }
     
-    private func performSearch(_ searchText: String) {
+    func performSearch(_ searchText: String) {
         guard !searchText.isEmpty else {
             filteredIngredients = []
             return
         }
         
         let lowercasedSearchText = searchText.lowercased()
-        let combinedArrays = ingredientNames + baseCategoryStrings + umbrellaCategoryStrings + specialtyCategoryStrings
-        let combinedArraysWithoutDuplicates = Array(Set(combinedArrays))
+        var seen = Set<String>()  // We create this set to make sure we have unique criteria.
         
-        filteredIngredients = combinedArraysWithoutDuplicates.filter { $0.lowercased().contains(lowercasedSearchText) }
+        filteredIngredients = (ingredientNames + baseCategoryStrings + umbrellaCategoryStrings + specialtyCategoryStrings).lazy //By making the arrays lazy, the combination, filtering, and sorting are done in a more efficient manner, only processing criteria as needed.
+            .filter { criteria in
+                let lowercasedCriteria = criteria.lowercased()
+                return lowercasedCriteria.contains(lowercasedSearchText) // This checks if the lowercasedSearchText is contained within lowercasedCriteria.
+                && seen.insert(lowercasedCriteria).inserted  // This checks if lowercasedCriteria was successfully inserted into the seen set (it's unique).
+            }
             .sorted { lhs, rhs in
                 let lhsLowercased = lhs.lowercased()
                 let rhsLowercased = rhs.lowercased()
@@ -356,8 +360,11 @@ final class SearchViewModel: ObservableObject {
                 
                 return (lhsLowercased.range(of: lowercasedSearchText)?.lowerBound ?? lhsLowercased.endIndex) < (rhsLowercased.range(of: lowercasedSearchText)?.lowerBound ?? rhsLowercased.endIndex)
             }
+            .prefix(25) // limits the results to the first 25 matches, which can significantly reduce the workload if you expect a large number of matches.
+            .map { $0 } // Finalize the lazy collection into an array
     }
-    
+
+
     @ViewBuilder
     func returnPreferencesThumbCell(ingredient: Binding<String> ) -> some View {
         

--- a/MetaCocktailsSwiftData/Views/Search View/SubViews/PreferencesIncludedLimitedThumbCell.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SubViews/PreferencesIncludedLimitedThumbCell.swift
@@ -50,6 +50,7 @@ struct PreferencesIncludedLimitedThumbCell: View {
                      } else {
                          viewModel.unwantedSelections.removeAll(where: {$0 == ingredient})
                      }
+                     viewModel.updateCategoryIngredients()
                      viewModel.fillUnwantedCategoryArrays()
                      viewModel.currentComponentSearchName = ""
                  }

--- a/MetaCocktailsSwiftData/Views/Search View/SubViews/PreferencesThumbsCell.swift
+++ b/MetaCocktailsSwiftData/Views/Search View/SubViews/PreferencesThumbsCell.swift
@@ -47,6 +47,7 @@ struct PreferencesThumbsCell: View {
                         viewModel.preferredSelections.removeAll(where: {$0 == ingredient})
                         viewModel.preferredCount -= 1
                     }
+                    viewModel.updateCategoryIngredients()
                     viewModel.fillPreferredCategoryArrays()
                     viewModel.currentComponentSearchName = ""
                     
@@ -80,6 +81,7 @@ struct PreferencesThumbsCell: View {
                     } else {
                         viewModel.unwantedSelections.removeAll(where: {$0 == ingredient})
                     }
+                    viewModel.updateCategoryIngredients()
                     viewModel.fillUnwantedCategoryArrays()
                     viewModel.currentComponentSearchName = ""
                 }


### PR DESCRIPTION
filteredIngredients was one massive array and it was slowing down performance. 

I made the arrays lazy, only processing the criteria when needed, reducing the overall workload and memory usage.

I changed the way we remove duplicates, creating a "Seen" set that checks as it's filtering the returned array.
By using a Set to track seen elements during filtering efficiently removes duplicates on-the-fly. This avoids the overhead of creating a combined array and then removing duplicates afterward.

Finally, we limit the number of matches that are shown to 25 with .prefix(25), reducing the amount of data that needs to be processed, filtered, and sorted, making the search faster, especially when dealing with our big ass array.

All this together runs the search much faster. 





