### PR TITLE
Removed animation from AlphabetNavigation

### DIFF
--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
@@ -37,15 +37,10 @@ struct CocktailListView: View {
                                     .listStyle(.plain)
                                     .frame(width: listGeo.size.width * 0.90)
                                     .onChange(of: selectedNavigationLetter) { oldValue, newValue in
-                                        if let letter = newValue {
-                                            withAnimation {
-                                                proxy.scrollTo(letter, anchor: .top)
-                                            }
+                                        proxy.scrollTo(newValue, anchor: .top)
                                             selectedNavigationLetter = nil
-                                        }
                                     }
                                 }
-                                
                                 AlphabetNavigationView(selectedLetter: $selectedNavigationLetter, alphabet: viewModel.cocktailListAlphabet)
                                     .frame(width: listGeo.size.width * 0.1)
                                     .opacity(searchBarIsFocused ? 0 : 1)


### PR DESCRIPTION
The animation is what was causing the cells not to load.

If the user hits a letter at the beginning of the alphabet, then the animation begins, then hits Z without the animation ending, the list fails to load the letters that did't visibly show on the screen.

Because the view is snapping directly to the letter without loading all of the cells in between, you can hit any letter as fast as you want without the sections getting cut off because of the lag from the animation. 

