### PR TITLE
Removed .onAppear modifier that was clearing ingredientName

### DIFF
--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -295,6 +295,7 @@ import Combine
         dynamicallyChangeMeasurementUnit()
         didChooseExistingIngredient = true
         isEdit.toggle()
+        
     }
     func customIngredientIsValid(allIngredients: [IngredientBase]) -> Bool {
         

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
@@ -88,10 +88,6 @@ struct AddIngredientSearchView: View {
                         viewModel.matchAllIngredients(ingredients: ingredients)
                     }
             }
-            .onAppear {
-                keyboardFocused = true
-                viewModel.ingredientName = ""
-            }
             if keyboardFocused {
                 ForEach(viewModel.filteredIngredients, id: \.name) { ingredient in
                     Button {


### PR DESCRIPTION
viewModel.ingredientName was getting cleared for no reason .onAppear on AddIngredientSearchView. 

Now the correct existing ingredient name populates when you want to edit an added ingredient. 