### PR TITLE
Unbreak the data model

### DIFF
--- a/MetaCocktailsSwiftData/EntryPoint/MetaCocktailsSwiftDataApp.swift
+++ b/MetaCocktailsSwiftData/EntryPoint/MetaCocktailsSwiftDataApp.swift
@@ -22,7 +22,6 @@ struct MetaCocktailsSwiftDataApp: App {
                 .modelContainer(container)
                 .preferredColorScheme(.dark)
                 .environmentObject(CBCViewModel())
-                .environmentObject(CocktailListViewModel(container: container))
         }
     }
 }
@@ -37,8 +36,9 @@ struct ContentView: View {
     
     var body: some View {
         ZStack {
-            TabBarView().opacity(viewModel.cocktailFetchCompleted ? 1 : 0)
-            FirstLaunchLoadingView().opacity(viewModel.cocktailFetchCompleted ? 0 : 1).allowsHitTesting(false)
+            TabBarView()//.opacity(viewModel.cocktailFetchCompleted ? 1 : 0)
+                .environmentObject(CocktailListViewModel(modelContext: modelContext))
+//            FirstLaunchLoadingView()//.opacity(viewModel.cocktailFetchCompleted ? 0 : 1).allowsHitTesting(false)
         }
     }
 }

--- a/MetaCocktailsSwiftData/EntryPoint/MetaCocktailsSwiftDataApp.swift
+++ b/MetaCocktailsSwiftData/EntryPoint/MetaCocktailsSwiftDataApp.swift
@@ -18,7 +18,7 @@ struct MetaCocktailsSwiftDataApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(viewModel: CocktailListViewModel(modelContext: container.mainContext))
                 .modelContainer(container)
                 .preferredColorScheme(.dark)
                 .environmentObject(CBCViewModel())
@@ -27,18 +27,18 @@ struct MetaCocktailsSwiftDataApp: App {
 }
 
 struct ContentView: View {
-
-    @Environment(\.modelContext) var modelContext
-    @EnvironmentObject var viewModel: CocktailListViewModel
     
-    @State private var swiftDataIsLoaded = false
+    @StateObject var viewModel: CocktailListViewModel
     @State private var startTime = CFAbsoluteTimeGetCurrent()
     
     var body: some View {
         ZStack {
-            TabBarView()//.opacity(viewModel.cocktailFetchCompleted ? 1 : 0)
-                .environmentObject(CocktailListViewModel(modelContext: modelContext))
-//            FirstLaunchLoadingView()//.opacity(viewModel.cocktailFetchCompleted ? 0 : 1).allowsHitTesting(false)
+            TabBarView()
+                .opacity(viewModel.cocktailFetchCompleted ? 1 : 0)
+            FirstLaunchLoadingView()
+                .opacity(viewModel.cocktailFetchCompleted ? 0 : 1)
+                .allowsHitTesting(false)
         }
+        .environmentObject(viewModel)
     }
 }

--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
@@ -12,7 +12,7 @@ import Combine
 
 @Observable final class CocktailListViewModel: ObservableObject {
     
-    let modelContext: ModelContext
+//    let modelContext: ModelContext
     var cocktailFetchCompleted = false
     
     private var allCocktails: [Cocktail] = []
@@ -29,15 +29,16 @@ import Combine
     
     var shouldReloadCache = false
     
-    init(container: ModelContainer) {
-        modelContext = ModelContext(container)
+    init(modelContext: ModelContext) {
+//        self.modelContext = modelContext
         self.setupSearch()
         Task {
-            await fetchCocktails()
+            await fetchCocktails(modelContext: modelContext)
         }
     }
     
-    private func fetchCocktails() async {
+    @MainActor
+    private func fetchCocktails(modelContext: ModelContext) async {
         
         do {
             let fetchedCocktails = try {

--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListViewModel.swift
@@ -10,9 +10,9 @@ import SwiftData
 import Observation
 import Combine
 
+@MainActor
 @Observable final class CocktailListViewModel: ObservableObject {
     
-//    let modelContext: ModelContext
     var cocktailFetchCompleted = false
     
     private var allCocktails: [Cocktail] = []
@@ -30,14 +30,12 @@ import Combine
     var shouldReloadCache = false
     
     init(modelContext: ModelContext) {
-//        self.modelContext = modelContext
         self.setupSearch()
         Task {
             await fetchCocktails(modelContext: modelContext)
         }
     }
-    
-    @MainActor
+
     private func fetchCocktails(modelContext: ModelContext) async {
         
         do {


### PR DESCRIPTION
Before:

We were passing one modelContext to all the views, but creating a new one in the CocktailListViewModel.

After:

We now use the same modelContext everywhere, however the CocktailListViewModel is now on the main thread so I want to testflight this build to see if that causes animation stutters again.

There is another way to do this using model actor but that involves a lot of things I still need to wrap my head around and it's almost guaranteed to change in the next iOS version because it's a huge pain in the butt. If we need to go that route though I'll to the work, but I'm hoping this gets the job done for now and we can revise with the next swift data update.