### PR TITLE
Changed the functionality of an added ingredient

### DIFF
--- a/MetaCocktailsSwiftData/Model/Cocktails/Classics/Brooklyn.swift
+++ b/MetaCocktailsSwiftData/Model/Cocktails/Classics/Brooklyn.swift
@@ -17,8 +17,8 @@ var brooklyn = Cocktail(cocktailName: "Brooklyn",
                         collection: .originals,
                         titleCocktail: true)
 
-var brooklynSpec     =  [OldCocktailIngredient(.liqueurs(.maraschinoLiqueur), value: 1, unit: .teaspoon),
-                         OldCocktailIngredient(.amari(.amerPicon), value: 1, unit: .teaspoon),
+var brooklynSpec     =  [OldCocktailIngredient(.liqueurs(.maraschinoLiqueur), value: 1, unit: .dashes),
+                         OldCocktailIngredient(.amari(.amerPicon), value: 1, unit: .dashes),
                          OldCocktailIngredient(.fortifiedWines(.sweetVermouthAny), value: 1.5),
                          OldCocktailIngredient(.whiskies(.straightRye), value: 1.5)]
 

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailView.swift
@@ -18,7 +18,6 @@ struct AddCocktailView: View {
     @State private var isSelectingFromTemplate: Bool = false
     @FocusState private var cocktailBuildStepKeyboardFocused: Bool
     @State private var isShowingInfo = false
-    @State private var isEditingAddedIngredient: Bool = false
     
     var body: some View {
         
@@ -36,7 +35,7 @@ struct AddCocktailView: View {
                             .font(FontFactory.fontBody16)
                     }
                     
-                    AddedIngredientView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView, isEditingAddedIngredient: $isEditingAddedIngredient)
+                    AddedIngredientView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView)
                     
                     Section(header: Text("Extras").font(FontFactory.sectionHeader12)) {
                         GlassPickerButton(viewModel: viewModel)
@@ -126,7 +125,7 @@ struct AddCocktailView: View {
                 }
                 .fullScreenCover(isPresented: $isShowingAddIngredients) {
                     NavigationStack{
-                        AddExistingIngredientDetailView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView, isEditingAddedIngredient: $isEditingAddedIngredient)
+                        AddExistingIngredientDetailView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView)
                             .navigationBarBackButtonHidden(true)
                     }
                 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailView.swift
@@ -18,6 +18,7 @@ struct AddCocktailView: View {
     @State private var isSelectingFromTemplate: Bool = false
     @FocusState private var cocktailBuildStepKeyboardFocused: Bool
     @State private var isShowingInfo = false
+    @State private var isEditingAddedIngredient: Bool = false
     
     var body: some View {
         
@@ -35,7 +36,7 @@ struct AddCocktailView: View {
                             .font(FontFactory.fontBody16)
                     }
                     
-                    AddedIngredientView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView)
+                    AddedIngredientView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView, isEditingAddedIngredient: $isEditingAddedIngredient)
                     
                     Section(header: Text("Extras").font(FontFactory.sectionHeader12)) {
                         GlassPickerButton(viewModel: viewModel)
@@ -125,7 +126,7 @@ struct AddCocktailView: View {
                 }
                 .fullScreenCover(isPresented: $isShowingAddIngredients) {
                     NavigationStack{
-                        AddExistingIngredientDetailView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView)
+                        AddExistingIngredientDetailView(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isShowingCustomIngredientView: $isShowingCustomIngredientView, isEditingAddedIngredient: $isEditingAddedIngredient)
                             .navigationBarBackButtonHidden(true)
                     }
                 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -329,13 +329,7 @@ import Combine
         addedIngredients[index] = updatedIngredient
         isEdit = true
     }
-    func removeEditedIngredient() {
-        if let editIngredient = editedIngredient {
-            if let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == editIngredient.ingredientBase.name}) {
-                addedIngredients.remove(at: index)
-            }
-        }
-    }
+
     func updateEditedIngredient() {
         if let editedIngredient = editedIngredient,
            let index = addedIngredients.firstIndex(where: { $0.id == editedIngredient.id }),

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -111,6 +111,7 @@ import Combine
         buildOption = nil
         customVariationName = nil
         currentIngredientUUID = UUID()
+        clearIngredientData()
     }
     func clearIngredientData() {
         ingredientName = ""
@@ -143,13 +144,11 @@ import Combine
                                                    tags: ingredientSpec.ingredientBase.tags,
                                                    prep: ingredientSpec.ingredientBase.prep
             )
-            
             let newIngredient = Ingredient(id: UUID(),
                                            ingredientBase: newIngredientBase,
                                            value: ingredientSpec.value,
                                            unit: ingredientSpec.unit
             )
-            
             addedIngredients.append(newIngredient)
             
         }
@@ -162,9 +161,6 @@ import Combine
         authorYear = String(Calendar.current.component(.year, from: Date()))
         customVariationName = cocktail.cocktailName
         isRiff = true
-        
-        print("Populated from cocktail: \(cocktailName)")
-        print("Number of ingredients: \(addedIngredients.count)")
     }
 
     
@@ -245,6 +241,16 @@ import Combine
         }
         clearData()
     }
+    func populateExistingIngredient(ingredient: Ingredient) {
+        ingredientName = ingredient.ingredientBase.name
+        category = UmbrellaCategory(rawValue: ingredient.ingredientBase.umbrellaCategory) ?? UmbrellaCategory.agaves
+        ingredientTags = ingredient.ingredientBase.tags ?? Tags()
+        info = ingredient.ingredientBase.info
+        dynamicallyChangeMeasurementUnit()
+        didChooseExistingIngredient = true
+        editedIngredient = ingredient
+        isEdit = true
+    }
     func populateCustomIngredient(ingredient: Ingredient) {
         if let prep = ingredient.ingredientBase.prep {
             prepIngredientRecipe = prep.prepRecipe
@@ -283,19 +289,8 @@ import Combine
             prepIngredientRecipe[index].method = newMethod
         }
     }
-    func populateExistingIngredient(ingredient: Ingredient) {
-        ingredientName = ingredient.ingredientBase.name
-        category = UmbrellaCategory(rawValue: ingredient.ingredientBase.umbrellaCategory) ?? UmbrellaCategory.agaves
-        ingredientTags = ingredient.ingredientBase.tags ?? Tags()
-        info = ingredient.ingredientBase.info
-        dynamicallyChangeMeasurementUnit()
-        didChooseExistingIngredient = true
-        editedIngredient = ingredient
-        isEdit = true
-        
-    }
+ 
     func customIngredientIsValid(allIngredients: [IngredientBase]) -> Bool {
-        
         return ingredientName != "" &&
         ingredientAmount != nil &&
         !allIngredients.contains(where: { $0.name == ingredientName } )
@@ -316,7 +311,6 @@ import Combine
                 value: ingredientValue,
                 unit: selectedMeasurementUnit
             )
-            
             addedIngredients[index] = updatedIngredient
         }
     }
@@ -325,7 +319,6 @@ import Combine
             addedIngredients.remove(at: index)
         }
     }
-    
     
     func customGarnishIsValid(allGarnishes: [Garnish]) -> Bool {
         return currentGarnishName != "" &&
@@ -352,24 +345,6 @@ import Combine
         }
         return text
     }
-    
-    func customIngredientIsSpirit() -> Bool {
-        if category == .agaves || category == .amari || category == .bitters || category == .brandies || category == .fortifiedWines || category == .gins || category == .liqueurs || category == .otherAlcohol || category == .rums || category == .vodkas || category == .whiskies || category == .wines {
-            return true
-        }
-        
-        return false
-    }
-    func customIngredientIsNA() -> Bool {
-        if customIngredientIsSpirit() {
-            return false
-        }
-        
-        return true
-    }
-   
-
-   
     
     func matchAllIngredients(ingredients: [IngredientBase]) {
         
@@ -477,46 +452,11 @@ import Combine
         }
     }
     
-    static func getAllPhysicalComponents() -> [CocktailComponent] {
-        var cocktailComponentArray = [CocktailComponent]()
-        
-        cocktailComponentArray.append(contentsOf: Syrup.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: Juice.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: Herbs.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: Fruit.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: Seasoning.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: Soda.allCases.map({ $0.nAComponent}))
-        cocktailComponentArray.append(contentsOf: OtherNA.allCases.map({ $0.nAComponent}))
-        
-        cocktailComponentArray.append(contentsOf: Agave.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Brandy.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Gin.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: OtherAlcohol.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Rum.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Vodka.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Whiskey.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Liqueur.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: FortifiedWine.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Wine.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Bitters.allCases.map { $0.cockTailComponent })
-        cocktailComponentArray.append(contentsOf: Amaro.allCases.map { $0.cockTailComponent })
-        
-     
-        
-        return cocktailComponentArray
-        
-    }
-    
- 
-    
     func validateAuthor() {
         if authorName != "" && authorYear != "" && authorPlace != "" {
             author = Author(person: authorName, place: authorYear, year: authorPlace)
         }
     }
-    
-    
-    
     
     init() {
         setupSearch()

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -259,7 +259,8 @@ import Combine
         prep = ingredient.ingredientBase.prep
         ingredientAmount = ingredient.value
         selectedMeasurementUnit = MeasurementUnit(rawValue: ingredient.unit.rawValue) ?? MeasurementUnit.fluidOunces
-        isEdit.toggle()
+        editedIngredient = ingredient
+        isEdit = true
     }
     func populateBuildStepFor(instruction: Instruction) {
         currentBuildStep = instruction.step
@@ -295,7 +296,7 @@ import Combine
         dynamicallyChangeMeasurementUnit()
         didChooseExistingIngredient = true
         editedIngredient = ingredient
-        isEdit.toggle()
+        isEdit = true
         
     }
     func customIngredientIsValid(allIngredients: [IngredientBase]) -> Bool {
@@ -310,7 +311,8 @@ import Combine
         }
     }
 
-    func updateEditedIngredient() {
+
+    func updateEditedIngredient(isCustom: Bool) {
         if let editedIngredient = editedIngredient,
            let index = addedIngredients.firstIndex(where: { $0.id == editedIngredient.id }),
            let ingredientValue = ingredientAmount {
@@ -320,7 +322,7 @@ import Combine
                 ingredientBase: IngredientBase(
                     name: ingredientName,
                     category: category,
-                    prep: prep
+                    prep: prep, isCustom: isCustom
                 ),
                 value: ingredientValue,
                 unit: selectedMeasurementUnit

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -43,6 +43,7 @@ import Combine
     var ingredientName = ""
     var info: String?
     var addedIngredients: [Ingredient] = []
+    var editedIngredient: Ingredient? = nil  
     var didChooseExistingIngredient: Bool = false
     var isShowingingredientAlert: Bool = false
  
@@ -293,6 +294,7 @@ import Combine
         info = ingredient.ingredientBase.info
         dynamicallyChangeMeasurementUnit()
         didChooseExistingIngredient = true
+        editedIngredient = ingredient
         isEdit.toggle()
         
     }
@@ -305,6 +307,53 @@ import Combine
     func removeIngredient() {
         if let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == ingredientName}) {
             addedIngredients.remove(at: index)
+        }
+    }
+    func replaceIngredient() {
+        guard let ingredientValue = ingredientAmount,
+              let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == ingredientName }) else {
+            return
+        }
+        
+        let updatedIngredient = Ingredient(
+            id: addedIngredients[index].id,
+            ingredientBase: IngredientBase(
+                name: ingredientName,
+                category: category,
+                prep: prep
+            ),
+            value: ingredientValue,
+            unit: selectedMeasurementUnit
+        )
+        
+        addedIngredients[index] = updatedIngredient
+        isEdit = true
+    }
+    func removeEditedIngredient() {
+        if let editIngredient = editedIngredient {
+            if let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == editIngredient.ingredientBase.name}) {
+                addedIngredients.remove(at: index)
+            }
+        }
+    }
+    func updateEditedIngredient() {
+        if let editedIngredient = editedIngredient,
+           let index = addedIngredients.firstIndex(where: { $0.id == editedIngredient.id }),
+           let ingredientValue = ingredientAmount {
+            
+            let updatedIngredient = Ingredient(
+                id: editedIngredient.id,
+                ingredientBase: IngredientBase(
+                    name: ingredientName,
+                    category: category,
+                    prep: prep
+                ),
+                value: ingredientValue,
+                unit: selectedMeasurementUnit
+            )
+            
+            
+            addedIngredients[index] = updatedIngredient
         }
     }
     func swipeToRemoveIngredient() {

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -19,14 +19,11 @@ import Combine
     var category: UmbrellaCategory = UmbrellaCategory.agaves
     var ingredientAmount: Double? = nil
     var ingredientTags = Tags()
-    
     var selectedMeasurementUnit = MeasurementUnit.fluidOunces
-    var currentSelectedComponent = CocktailComponent(name: "Placeholder")
     var filteredIngredients: [IngredientBase] = []
 
     var isShowingAlert: Bool = false
-    var dateAdded = Date()
-    var defaultName = "Add Cocktail"
+
     
     var  formatter: NumberFormatter = {
         let formatter = NumberFormatter()
@@ -52,7 +49,6 @@ import Combine
     var currentGarnishName: String = ""
     var customGarnishNameEntered: String? 
     var didChooseExistingGarnish: Bool = false
-    var addExistingGarnishViewIsActive: Bool = false
     var filteredGarnish: [String] = []
     
     // Extras
@@ -111,7 +107,6 @@ import Combine
         addedGarnish = []
         variation = nil
         addedIngredients = []
-        defaultName = "Add Cocktail"
         build = Build(instructions: [])
         buildOption = nil
         customVariationName = nil
@@ -305,12 +300,6 @@ import Combine
         ingredientAmount != nil &&
         !allIngredients.contains(where: { $0.name == ingredientName } )
     }
-    func removeIngredient() {
-        if let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == ingredientName}) {
-            addedIngredients.remove(at: index)
-        }
-    }
-
 
     func updateEditedIngredient(isCustom: Bool) {
         if let editedIngredient = editedIngredient,

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/AddCocktailViewModel.swift
@@ -309,26 +309,6 @@ import Combine
             addedIngredients.remove(at: index)
         }
     }
-    func replaceIngredient() {
-        guard let ingredientValue = ingredientAmount,
-              let index = addedIngredients.firstIndex(where: { $0.ingredientBase.name == ingredientName }) else {
-            return
-        }
-        
-        let updatedIngredient = Ingredient(
-            id: addedIngredients[index].id,
-            ingredientBase: IngredientBase(
-                name: ingredientName,
-                category: category,
-                prep: prep
-            ),
-            value: ingredientValue,
-            unit: selectedMeasurementUnit
-        )
-        
-        addedIngredients[index] = updatedIngredient
-        isEdit = true
-    }
 
     func updateEditedIngredient() {
         if let editedIngredient = editedIngredient,
@@ -345,7 +325,6 @@ import Combine
                 value: ingredientValue,
                 unit: selectedMeasurementUnit
             )
-            
             
             addedIngredients[index] = updatedIngredient
         }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
@@ -14,6 +14,7 @@ struct AddedIngredientView: View {
     @Binding var isShowingAddIngredients: Bool
     @Binding var isShowingCustomIngredientView: Bool 
     @Environment(\.modelContext) private var modelContext
+    @Binding var isEditingAddedIngredient: Bool 
     
     var body: some View {
         
@@ -38,10 +39,12 @@ struct AddedIngredientView: View {
                             if ingredient.ingredientBase.isCustom {
                                 viewModel.currentIngredientUUID = ingredient.id 
                                 viewModel.populateCustomIngredient(ingredient: ingredient)
+                                isEditingAddedIngredient = true
                                 isShowingCustomIngredientView.toggle()
                             } else {
                                 viewModel.currentIngredientUUID = ingredient.id
                                 viewModel.populateExistingIngredient(ingredient: ingredient)
+                                isEditingAddedIngredient = true
                                 isShowingAddIngredients.toggle()
                             }
                         })
@@ -76,7 +79,7 @@ struct AddedIngredientView: View {
 #Preview {
     let preview = PreviewContainer([Cocktail.self], isStoredInMemoryOnly: true)
     
-    AddedIngredientView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true))
+    AddedIngredientView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true), isEditingAddedIngredient: .constant(false))
         .modelContainer(preview.container)
     
 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
@@ -14,7 +14,7 @@ struct AddedIngredientView: View {
     @Binding var isShowingAddIngredients: Bool
     @Binding var isShowingCustomIngredientView: Bool 
     @Environment(\.modelContext) private var modelContext
-    @Binding var isEditingAddedIngredient: Bool 
+
     
     var body: some View {
         
@@ -39,12 +39,12 @@ struct AddedIngredientView: View {
                             if ingredient.ingredientBase.isCustom {
                                 viewModel.currentIngredientUUID = ingredient.id 
                                 viewModel.populateCustomIngredient(ingredient: ingredient)
-                                isEditingAddedIngredient = true
+                                viewModel.isEdit = true
                                 isShowingCustomIngredientView.toggle()
                             } else {
                                 viewModel.currentIngredientUUID = ingredient.id
                                 viewModel.populateExistingIngredient(ingredient: ingredient)
-                                isEditingAddedIngredient = true
+                                viewModel.isEdit = true
                                 isShowingAddIngredients.toggle()
                             }
                         })
@@ -62,6 +62,9 @@ struct AddedIngredientView: View {
             }
             
             Button {
+                viewModel.isEdit = false
+                viewModel.ingredientName = ""
+                viewModel.matchAllIngredients(ingredients: [])
                 isShowingAddIngredients.toggle()
             } label: {
                 HStack{
@@ -79,7 +82,7 @@ struct AddedIngredientView: View {
 #Preview {
     let preview = PreviewContainer([Cocktail.self], isStoredInMemoryOnly: true)
     
-    AddedIngredientView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true), isEditingAddedIngredient: .constant(false))
+    AddedIngredientView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true))
         .modelContainer(preview.container)
     
 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/AddedIngredientView.swift
@@ -39,12 +39,10 @@ struct AddedIngredientView: View {
                             if ingredient.ingredientBase.isCustom {
                                 viewModel.currentIngredientUUID = ingredient.id 
                                 viewModel.populateCustomIngredient(ingredient: ingredient)
-                                viewModel.isEdit = true
                                 isShowingCustomIngredientView.toggle()
                             } else {
                                 viewModel.currentIngredientUUID = ingredient.id
                                 viewModel.populateExistingIngredient(ingredient: ingredient)
-                                viewModel.isEdit = true
                                 isShowingAddIngredients.toggle()
                             }
                         })

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/CustomIngredient/AddCustomIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/CustomIngredient/AddCustomIngredientView.swift
@@ -115,7 +115,6 @@ struct AddCustomIngredientToCocktailButton: View {
         Section {
             UniversalButton(buttonText: "Add to spec", rightImage: Image(systemName: "plus"), includeBorder: true) {
                 if viewModel.customIngredientIsValid(allIngredients: ingredients) {
-                    //viewModel.removeIngredient()
                     if viewModel.isEdit {
                         viewModel.updateEditedIngredient(isCustom: true)
                     }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/CustomIngredient/AddCustomIngredientView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/CustomIngredient/AddCustomIngredientView.swift
@@ -115,20 +115,22 @@ struct AddCustomIngredientToCocktailButton: View {
         Section {
             UniversalButton(buttonText: "Add to spec", rightImage: Image(systemName: "plus"), includeBorder: true) {
                 if viewModel.customIngredientIsValid(allIngredients: ingredients) {
-                    viewModel.removeIngredient()
-                    
-                    if !viewModel.prepIngredientRecipe.isEmpty {
-                        viewModel.prep = Prep(prepIngredientName: viewModel.ingredientName, prepRecipe: viewModel.prepIngredientRecipe)
+                    //viewModel.removeIngredient()
+                    if viewModel.isEdit {
+                        viewModel.updateEditedIngredient(isCustom: true)
                     }
-                    if let ingredientValue = viewModel.ingredientAmount {
-                        viewModel.addedIngredients.append(Ingredient(ingredientBase: IngredientBase(name: viewModel.ingredientName,
-                                                                                                    category: viewModel.category,
-                                                                                                    prep: viewModel.prep, isCustom: true),
-                                                                     value: ingredientValue,
-                                                                     unit: viewModel.selectedMeasurementUnit))
+                    if !viewModel.isEdit {
+                        if !viewModel.prepIngredientRecipe.isEmpty {
+                            viewModel.prep = Prep(prepIngredientName: viewModel.ingredientName, prepRecipe: viewModel.prepIngredientRecipe)
+                        }
+                        if let ingredientValue = viewModel.ingredientAmount {
+                            viewModel.addedIngredients.append(Ingredient(ingredientBase: IngredientBase(name: viewModel.ingredientName,
+                                                                                                        category: viewModel.category,
+                                                                                                        prep: viewModel.prep, isCustom: true),
+                                                                         value: ingredientValue,
+                                                                         unit: viewModel.selectedMeasurementUnit))
+                        }
                     }
-                    
-                    
                     viewModel.clearIngredientData()
                     isShowingAddIngredients = false
                     isShowingCustomIngredientView = false

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
@@ -105,7 +105,9 @@ struct AddIngredientSearchView: View {
                     } label: {
                         Text(ingredient.name)
                     }
-                    .tint(.primary)
+                    .foregroundStyle(viewModel.addedIngredients.contains(where: { $0.ingredientBase.name == ingredient.name}) ? Color.gray : .white)
+                    .disabled(viewModel.addedIngredients.contains(where: { $0.ingredientBase.name == ingredient.name}) ? true : false )
+                    
                 }
                 .listStyle(.plain)
                 .listRowBackground(Color.clear)
@@ -183,7 +185,7 @@ struct AddExistingIngredientToCocktailButton: View {
         
         UniversalButton(buttonText: "Add to spec", rightImage: Image(systemName: "plus"), includeBorder: true) {
             if viewModel.existingIngredientIsValid(allIngredients: ingredients) {
-                viewModel.replaceIngredient()
+         
                 if viewModel.isEdit {
                     viewModel.updateEditedIngredient()
                 }

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
@@ -187,7 +187,7 @@ struct AddExistingIngredientToCocktailButton: View {
             if viewModel.existingIngredientIsValid(allIngredients: ingredients) {
          
                 if viewModel.isEdit {
-                    viewModel.updateEditedIngredient()
+                    viewModel.updateEditedIngredient(isCustom: false)
                 }
                 if !viewModel.isEdit {
                     if let ingredientValue = viewModel.ingredientAmount{

--- a/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
+++ b/MetaCocktailsSwiftData/Views/CreateACocktailView/SubViews/AddIngredient/ExistingIngredient/AddExistingIngredientDetailView.swift
@@ -16,6 +16,7 @@ struct AddExistingIngredientDetailView: View {
     @Binding var isShowingCustomIngredientView: Bool
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    @Binding var isEditingAddedIngredient: Bool
     
     var body: some View {
         
@@ -29,7 +30,7 @@ struct AddExistingIngredientDetailView: View {
                     AddIngredientSearchView(viewModel: viewModel, keyboardFocused: _keyboardFocused, amountKeyboardFocused: _amountKeyboardFocused)
                     AddMeasurementView(viewModel: viewModel, amountKeyboardFocused: _amountKeyboardFocused)
                     Section {
-                        AddExistingIngredientToCocktailButton(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients)
+                        AddExistingIngredientToCocktailButton(viewModel: viewModel, isShowingAddIngredients: $isShowingAddIngredients, isEditingAddedIngredient: $isEditingAddedIngredient)
                     }
                     .listRowBackground(Color.clear)
                     Section {
@@ -47,6 +48,9 @@ struct AddExistingIngredientDetailView: View {
                 } else {
                     keyboardFocused = true
                 }
+                if isEditingAddedIngredient {
+                    
+                }
             }
         }
     }
@@ -55,7 +59,7 @@ struct AddExistingIngredientDetailView: View {
 #Preview {
     let preview = PreviewContainer([Cocktail.self], isStoredInMemoryOnly: true)
     
-    AddExistingIngredientDetailView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true))
+    AddExistingIngredientDetailView(viewModel: AddCocktailViewModel(), isShowingAddIngredients: .constant(true), isShowingCustomIngredientView: .constant(true), isEditingAddedIngredient: .constant(false))
         .modelContainer(preview.container)
     
 }
@@ -178,20 +182,26 @@ struct AddExistingIngredientToCocktailButton: View {
     @Bindable var viewModel: AddCocktailViewModel
     @Query(sort: \IngredientBase.name) var ingredients: [IngredientBase]
     @Binding  var isShowingAddIngredients: Bool
+    @Binding var isEditingAddedIngredient: Bool
     
     var body: some View {
         
         UniversalButton(buttonText: "Add to spec", rightImage: Image(systemName: "plus"), includeBorder: true) {
             if viewModel.existingIngredientIsValid(allIngredients: ingredients) {
-                viewModel.removeIngredient()
-                if let ingredientValue = viewModel.ingredientAmount{
-                    let ingredient = Ingredient(ingredientBase: IngredientBase(name: viewModel.ingredientName,
-                                                                               category: viewModel.category,
-                                                                               prep: viewModel.prep),
-                                                value: ingredientValue,
-                                                unit: viewModel.selectedMeasurementUnit)
-                    
-                    viewModel.addedIngredients.append(ingredient)
+                viewModel.replaceIngredient()
+                if isEditingAddedIngredient {
+                    viewModel.updateEditedIngredient()
+                }
+                if !viewModel.isEdit {
+                    if let ingredientValue = viewModel.ingredientAmount{
+                        let ingredient = Ingredient(ingredientBase: IngredientBase(name: viewModel.ingredientName,
+                                                                                   category: viewModel.category,
+                                                                                   prep: viewModel.prep),
+                                                    value: ingredientValue,
+                                                    unit: viewModel.selectedMeasurementUnit)
+                        
+                        viewModel.addedIngredients.append(ingredient)
+                    }
                 }
                 
                 viewModel.clearIngredientData()


### PR DESCRIPTION
Now, the user can edit any ingredient value or name while retaining the index and position in the array.

Before, we were removing the old ingredient then adding a new one to the array. So if the user wanted to edit an ingredient, it would end up at the end of the array instead of retaining the position. 

This makes the editing less confusing. 