### PR TITLE
Fix: Expandable cocktail list animation 

### DIFF
--- a/MetaCocktailsSwiftData/Views/Cocktail List View/SubViews/AllCocktailsListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/SubViews/AllCocktailsListView.swift
@@ -111,7 +111,10 @@ struct CocktailGroupView: View {
                 if isExpanded {
                     ForEach(cocktails, id: \.id) { cocktail in
                         MultipleCocktailsListView(cocktail: cocktail, cocktails: cocktails)
-                            .transition(.opacity)
+                            .transition(.asymmetric(
+                                insertion: AnyTransition.opacity.animation(.easeIn),
+                                removal: AnyTransition.opacity.animation(.easeOut.speed(2))
+                            ))
                     }
                 }
             }


### PR DESCRIPTION
When expanding the groups in the cocktail list, the text would overlap with rest of the cocktail list for a split second. We can use the asymmetric transition to make the cocktail animation happen quickly when they disappear , but a little slower when they show up.