### PR TITLE
Added a PrepBibleView

### DIFF
--- a/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
+++ b/MetaCocktailsSwiftData.xcodeproj/project.pbxproj
@@ -405,6 +405,10 @@
 		4DBFF8572B60AAFB0011B5B1 /* CableCar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF8562B60AAFB0011B5B1 /* CableCar.swift */; };
 		4DBFF8592B60AD800011B5B1 /* CableCar(W&G).swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF8582B60AD800011B5B1 /* CableCar(W&G).swift */; };
 		4DBFF85B2B60AFE60011B5B1 /* Carajillo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DBFF85A2B60AFE60011B5B1 /* Carajillo.swift */; };
+		4DC058E82DA5BEAF006AAE5B /* PrepBibleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC058E72DA5BEAF006AAE5B /* PrepBibleViewModel.swift */; };
+		4DC058EC2DA5C41F006AAE5B /* PrepBibleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC058EB2DA5C41F006AAE5B /* PrepBibleView.swift */; };
+		4DC058EE2DA5C459006AAE5B /* ResourcesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC058ED2DA5C459006AAE5B /* ResourcesView.swift */; };
+		4DC058F62DA5D21E006AAE5B /* PrepBibleRecipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DC058F52DA5D21E006AAE5B /* PrepBibleRecipeView.swift */; };
 		4DCAA7A52C35E77200FBC4FE /* CustomIngredientRecipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCAA7A42C35E77200FBC4FE /* CustomIngredientRecipeView.swift */; };
 		4DCAA7A72C35E83F00FBC4FE /* AddRecipeStepDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCAA7A62C35E83F00FBC4FE /* AddRecipeStepDetailView.swift */; };
 		4DCAA7A92C373D1700FBC4FE /* AddIngredientDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4DCAA7A82C373D1700FBC4FE /* AddIngredientDetailView.swift */; };
@@ -973,6 +977,10 @@
 		4DBFF8562B60AAFB0011B5B1 /* CableCar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CableCar.swift; sourceTree = "<group>"; };
 		4DBFF8582B60AD800011B5B1 /* CableCar(W&G).swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CableCar(W&G).swift"; sourceTree = "<group>"; };
 		4DBFF85A2B60AFE60011B5B1 /* Carajillo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Carajillo.swift; sourceTree = "<group>"; };
+		4DC058E72DA5BEAF006AAE5B /* PrepBibleViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepBibleViewModel.swift; sourceTree = "<group>"; };
+		4DC058EB2DA5C41F006AAE5B /* PrepBibleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepBibleView.swift; sourceTree = "<group>"; };
+		4DC058ED2DA5C459006AAE5B /* ResourcesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourcesView.swift; sourceTree = "<group>"; };
+		4DC058F52DA5D21E006AAE5B /* PrepBibleRecipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepBibleRecipeView.swift; sourceTree = "<group>"; };
 		4DCAA7A42C35E77200FBC4FE /* CustomIngredientRecipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomIngredientRecipeView.swift; sourceTree = "<group>"; };
 		4DCAA7A62C35E83F00FBC4FE /* AddRecipeStepDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddRecipeStepDetailView.swift; sourceTree = "<group>"; };
 		4DCAA7A82C373D1700FBC4FE /* AddIngredientDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddIngredientDetailView.swift; sourceTree = "<group>"; };
@@ -1392,6 +1400,7 @@
 		1AC386962AAABED00064F52A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				4DC058E02DA5BC6E006AAE5B /* ResourcesView */,
 				4DABDD1C2CEBC47F0080A529 /* AboutUsView */,
 				F493F3B22C6D256F006A0ADB /* Design */,
 				4D5DA09C2B9ED43300C14F1F /* CustomAlertView */,
@@ -1441,6 +1450,9 @@
 		1AC3869E2AAABED00064F52A /* Prep Bible */ = {
 			isa = PBXGroup;
 			children = (
+				4DC058F52DA5D21E006AAE5B /* PrepBibleRecipeView.swift */,
+				4DC058EB2DA5C41F006AAE5B /* PrepBibleView.swift */,
+				4DC058E72DA5BEAF006AAE5B /* PrepBibleViewModel.swift */,
 				4DB1C08F2B2E484A00943C69 /* Prep Descriptions */,
 				1AC3869F2AAABED00064F52A /* PrepRecipeView.swift */,
 				1AC386A12AAABED00064F52A /* PrepBible.swift */,
@@ -1998,6 +2010,14 @@
 			path = "General Cocktail Instructions";
 			sourceTree = "<group>";
 		};
+		4DC058E02DA5BC6E006AAE5B /* ResourcesView */ = {
+			isa = PBXGroup;
+			children = (
+				4DC058ED2DA5C459006AAE5B /* ResourcesView.swift */,
+			);
+			path = ResourcesView;
+			sourceTree = "<group>";
+		};
 		4DE33DF52B8D931500312EC3 /* CreateACocktailView */ = {
 			isa = PBXGroup;
 			children = (
@@ -2362,6 +2382,7 @@
 				4DCAA7A52C35E77200FBC4FE /* CustomIngredientRecipeView.swift in Sources */,
 				F4D185012C8F95370035B280 /* Brancolada.swift in Sources */,
 				4DBFF83F2B6082E40011B5B1 /* Boulevardier(W&G).swift in Sources */,
+				4DC058E82DA5BEAF006AAE5B /* PrepBibleViewModel.swift in Sources */,
 				4D5DA08E2B9E8E6A00C14F1F /* AddBuildStepDetailView.swift in Sources */,
 				4DF408D02B60EBDE00EF9A6E /* CloverClub(W&G).swift in Sources */,
 				4DBBA44E2B673E3D00179B8F /* HoneymoonCocktail1st.swift in Sources */,
@@ -2603,6 +2624,7 @@
 				1AC386C02AAABED10064F52A /* BlackberrySageSmash.swift in Sources */,
 				4DBFF84F2B609F1F0011B5B1 /* BrownDerby(OGRumVersion).swift in Sources */,
 				F40FB6B12B7E38DA0047D597 /* CocktailCollection.swift in Sources */,
+				4DC058F62DA5D21E006AAE5B /* PrepBibleRecipeView.swift in Sources */,
 				4DA567582B6C43CA003F6F04 /* UltimaPalabra(London).swift in Sources */,
 				4DBBA42A2B65A2FC00179B8F /* Grasshopper.swift in Sources */,
 				4DBBA4D32B6A425B00179B8F /* RememberTheMaine(OG).swift in Sources */,
@@ -2645,6 +2667,7 @@
 				4DBBA4702B67A35300179B8F /* KentuckyMaid(W&G).swift in Sources */,
 				4DBAE6F32C713D7400F3DBFD /* WhiteLinen.swift in Sources */,
 				1AFDB7D22AE3477A000A3812 /* Margarita.swift in Sources */,
+				4DC058EE2DA5C459006AAE5B /* ResourcesView.swift in Sources */,
 				4DA5674A2B6C32E4003F6F04 /* TiPunch(W&G).swift in Sources */,
 				4D5DA0B62BA127BD00C14F1F /* PiscoSour(W&G Version).swift in Sources */,
 				F4FBF1232AAABBB900BBF7CF /* MetaCocktailsSwiftDataApp.swift in Sources */,
@@ -2794,6 +2817,7 @@
 				4DAD6C922C83B86C00860555 /* RiffPickerView.swift in Sources */,
 				4D54F73E2B7B053800D046D9 /* LoadedCocktailIngredientCell.swift in Sources */,
 				4DA5677A2B6C90E9003F6F04 /* CleverGirl.swift in Sources */,
+				4DC058EC2DA5C41F006AAE5B /* PrepBibleView.swift in Sources */,
 				F4D7C0122CBC3D7100B8D9C0 /* IngredientPrepOverlay.swift in Sources */,
 				4DA567F22B6DE424003F6F04 /* BurisBovineBeverage.swift in Sources */,
 				4DA567C82B6DB8F5003F6F04 /* PrettyInParadox.swift in Sources */,

--- a/MetaCocktailsSwiftData/Views/AboutUsView/AboutUsView.swift
+++ b/MetaCocktailsSwiftData/Views/AboutUsView/AboutUsView.swift
@@ -78,7 +78,7 @@ struct AboutUsView: View {
                             MattPicture()
                         }
                     }
-                    .aboutHeaderWithNavigation(title: "About Cocktail Copilot", dismiss: dismiss)
+                    .jamesHeaderWithNavigation(title: "About Cocktail Copilot", dismiss: dismiss)
                     .navigationBarTitleDisplayMode(.inline)
                     .background(
                         Image(.limeSegments)

--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
@@ -136,7 +136,7 @@ struct SearchBarForCocktailListView: View {
             NavigationStack {
                 
                 NavigationLink {
-                    AboutUsView()
+                    ResourcesView()
                         .navigationBarBackButtonHidden(true)
                 } label: {
                     

--- a/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleRecipeView.swift
+++ b/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleRecipeView.swift
@@ -1,0 +1,123 @@
+//
+//  PrepBibleRecipeView.swift
+//  MetaCocktailsSwiftData
+//
+//  Created by James Menkal on 4/8/25.
+//
+
+
+//
+//  PrepBibleRecipeView.swift
+//  MetaCocktails
+//
+//  Created on 4/8/25.
+//
+
+import SwiftUI
+import SwiftData 
+
+struct PrepBibleRecipeView: View {
+    let prep: Prep
+    @Environment(\.dismiss) private var dismiss
+    @State private var borderColor = ColorScheme.presentedFrontBorder
+    
+    var body: some View {
+        ZStack {
+            ColorScheme.background
+                .ignoresSafeArea()
+            
+            GeometryReader { outerGeo in
+                ZStack {
+                    BackgroundGlowAnimation(gradient: borderColor.top, isFavorite: .constant(false))
+                    
+                    VStack(alignment: .leading, spacing: 15) {
+                        // Header with back button
+                        HStack {
+                            Button(action: {
+                                dismiss()
+                            }) {
+                                Image(systemName: "chevron.backward")
+                                    .font(.system(size: 24))
+                                    .foregroundStyle(ColorScheme.interactionTint)
+                            }
+                            
+                            Spacer()
+                            
+                            Text(prep.prepIngredientName)
+                                .font(FontFactory.recipeCardHeader18B)
+                                .foregroundColor(.white)
+                            
+                            Spacer()
+                            
+                            // Empty space to balance the back button
+                            Color.clear
+                                .frame(width: 24, height: 24)
+                        }
+                        .padding(.bottom, 20)
+                        
+                        // Recipe instructions
+                        ScrollView {
+                            ForEach(prep.prepRecipe) { instruction in
+                                HStack(alignment: .top) {
+                                    Text("\(instruction.step).")
+                                        .font(FontFactory.mediumFont(size: 16))
+                                        .bold()
+                                    
+                                    Text(instruction.method)
+                                        .font(FontFactory.mediumFont(size: 16))
+                                }
+                                
+                                if instruction.step < prep.prepRecipe.last!.step {
+                                    Divider()
+                                }
+                            }
+                        }
+                        
+                        
+                        Spacer()
+                    }
+                    .padding(20)
+                    .background(BlackGlassBackgroundView())
+                    .frame(width: outerGeo.size.width * 0.88, height: outerGeo.contentSize(for: outerGeo.size.height))
+                    
+                    Border(height: outerGeo.size.height, gradient: $borderColor)
+                }
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+// Extension to match the content sizing from RecipeViewModel
+extension GeometryProxy {
+    func contentSize(for height: CGFloat) -> CGFloat {
+        switch height {
+        case 0..<650:
+            return height * 0.896
+        case 651..<672:
+            return height * 0.90
+        default:
+            return height * 0.91
+        }
+    }
+}
+
+// Preview struct
+struct PreviewPrep {
+    static let ginger = Prep(
+        prepIngredientName: "Ginger syrup",
+        prepRecipe: [
+            Instruction(step: 1, method: "This requires juicing fresh ginger, which can be a strain on household juicers."),
+            Instruction(step: 2, method: "Add equal parts fresh ginger juice and sugar to a pot and bring to a boil while stirring. Some prefer Demerara sugar for a darker and more robust flavor. You can use plain white sugar for a brighter and sharper flavor. The Williams and Graham method is to add black pepper and lemon juice in small proportions (highly recommend)."),
+            Instruction(step: 3, method: "Take off heat immediately after boiling and let cool."),
+            Instruction(step: 4, method: "Add 1oz(30ml) vodka to every 750ml of syrup to stabilize.")
+        ]
+    )
+}
+
+#Preview {
+    NavigationStack {
+        PrepBibleRecipeView(prep: PreviewPrep.ginger)
+    }
+}

--- a/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleView.swift
+++ b/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleView.swift
@@ -1,0 +1,253 @@
+//
+//  PrepBibleView.swift
+//  MetaCocktails
+//
+//  Created on 4/8/25.
+//
+
+import SwiftUI
+import SwiftData
+
+struct PrepBibleView: View {
+    
+    @StateObject private var viewModel = PrepBibleViewModel()
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+    @FocusState private var searchBarIsFocused: Bool
+    @State private var selectedNavigationLetter: String?
+    @Query private var ingredientBases: [IngredientBase]
+    
+    
+    var body: some View {
+        NavigationStack {
+            GeometryReader { outerGeo in
+                ZStack {
+                    ColorScheme.background.ignoresSafeArea()
+                    
+                    VStack(spacing: 0) {
+                        SearchBarForPrepBibleView(
+                            isFocused: $searchBarIsFocused,
+                            searchText: $viewModel.searchText,
+                            onSearchChanged: viewModel.updateSearch
+                        )
+                        
+                        GeometryReader { listGeo in
+                            HStack(spacing: 0) {
+                                ScrollViewReader { proxy in
+                                    ScrollView {
+                                        if searchBarIsFocused {
+                                            SearchBarPrepResultsView(prepRecipes: viewModel.filteredPrepRecipes)
+                                        } else {
+                                            AllPrepRecipesListView(
+                                                prepAlphabet: viewModel.prepAlphabet,
+                                                organizedPrep: viewModel.organizedPrepRecipes,
+                                                animatingLetter: $selectedNavigationLetter
+                                            )
+                                        }
+                                    }
+                                    .frame(width: listGeo.size.width * 0.90)
+                                    .onChange(of: selectedNavigationLetter) { oldValue, newValue in
+                                        if let newValue = newValue {
+                                            withAnimation(.easeOut(duration: 0.2)) {
+                                                proxy.scrollTo(newValue, anchor: .top)
+                                            }
+                                        }
+                                    }
+                                }
+                                
+                                // Only show alphabet navigation if we have items
+                                if !viewModel.prepAlphabet.isEmpty {
+                                    AlphabetNavigationViewForPrep(
+                                        selectedLetter: $selectedNavigationLetter,
+                                        alphabet: viewModel.prepAlphabet
+                                    )
+                                    .frame(width: listGeo.size.width * 0.1)
+                                    .opacity(searchBarIsFocused ? 0 : 1)
+                                    .animation(.easeInOut(duration: 0.3), value: searchBarIsFocused)
+                                    .offset(y: -7)
+                                }
+                            }
+                        }
+                    }
+                    .frame(height: outerGeo.size.height)
+                }
+            }
+            .task {
+                viewModel.loadPrepRecipes(from: ingredientBases)
+                searchBarIsFocused = false
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .jamesHeaderWithNavigation(title: "Prep Bible", dismiss: dismiss)
+        }
+    }
+}
+
+struct SearchBarForPrepBibleView: View {
+    @FocusState.Binding var isFocused: Bool
+    @Binding var searchText: String
+    var onSearchChanged: (String) -> Void
+    
+    var body: some View {
+        HStack {
+            TextField("Search prep recipes", text: $searchText)
+                .SearchBarTextField()
+                .focused($isFocused)
+                .sensoryFeedback(.impact(weight: .heavy), trigger: isFocused == true)
+                .animation(.easeInOut(duration: 0.2), value: isFocused)
+                .clearSearchButton(text: $searchText) {
+                    searchText = ""
+                    onSearchChanged("")
+                }
+                .onChange(of: searchText) { _, newValue in
+                    onSearchChanged(newValue)
+                }
+                .onSubmit {
+                    searchText = ""
+                }
+                .onTapGesture {
+                    isFocused = true
+                }
+                .onDisappear{
+                    searchText = ""
+                    isFocused = false
+                }
+                .submitLabel(.done)
+        }
+        .padding()
+    }
+}
+
+struct AlphabetNavigationViewForPrep: View {
+    @Binding var selectedLetter: String?
+    let alphabet: [String]
+    @State private var animatingLetter: String?
+    
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: 0) {
+                ForEach(alphabet, id: \.self) { letter in
+                    Button(action: {
+                        selectedLetter = letter
+                        withAnimation(.none) {
+                            animatingLetter = letter
+                        }
+                        withAnimation(.easeOut(duration: 0.5).delay(0.1)) {
+                            animatingLetter = nil
+                        }
+                    }) {
+                        Text(letter)
+                            .font(FontFactory.alphabetFont(for: geometry.size.height, isSelected: animatingLetter == letter))
+                            .foregroundColor(animatingLetter == letter ? ColorScheme.tintColor : .primary)
+                            .frame(width: geometry.size.width, height: geometry.size.height / CGFloat(alphabet.count))
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(ScaleButtonStyle())
+                    .sensoryFeedback(.impact(weight: .heavy), trigger: selectedLetter == letter)
+                }
+            }
+        }
+    }
+}
+
+struct AllPrepRecipesListView: View {
+    let prepAlphabet: [String]
+    let organizedPrep: [String: [Prep]]
+    @Binding var animatingLetter: String?
+    
+    var body: some View {
+        LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+            ForEach(prepAlphabet, id: \.self) { letter in
+                if let preps = organizedPrep[letter], !preps.isEmpty {
+                    Section {
+                        ForEach(preps, id: \.prepIngredientName) { prep in
+                            PrepItemView(prep: prep)
+                        }
+                    } header: {
+                        PrepSectionHeaderView(letter: letter, animatingLetter: $animatingLetter)
+                    }
+                    .id(letter)
+                }
+            }
+        }
+    }
+}
+
+struct PrepItemView: View {
+    let prep: Prep
+    
+    var body: some View {
+        NavigationLink{
+            PrepBibleRecipeView(prep: prep)
+        } label: {
+            HStack {
+                Text(prep.prepIngredientName)
+                    .font(FontFactory.regularFont(size: 18))
+                    .padding(.leading, 20)
+                    .foregroundStyle(.white)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .frame(height: 35)
+        .padding(.vertical, 2)
+    }
+}
+
+struct PrepSectionHeaderView: View {
+    let letter: String
+    @Binding var animatingLetter: String?
+    @State private var isAnimating: Bool = false
+    
+    var body: some View {
+        ZStack {
+            BlackGlassBackgroundView()
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+            
+            headerSelectionGradient
+            
+            HStack {
+                Text(letter)
+                    .font(FontFactory.listLetter(size: 28))
+                    .foregroundColor(isAnimating ? ColorScheme.tintColor : .secondary)
+                    .padding(.horizontal)
+                Spacer()
+            }
+        }
+        .task(id: animatingLetter) {
+            if letter == animatingLetter {
+                isAnimating = true
+                try? await Task.sleep(for: .milliseconds(100))
+                withAnimation(.easeOut(duration: 1.5)) {
+                    isAnimating = false
+                }
+                animatingLetter = nil
+            }
+        }
+    }
+    
+    var headerSelectionGradient: LinearGradient {
+        LinearGradient(
+            gradient: Gradient(colors: [
+                isAnimating ? ColorScheme.tintColor.opacity(0.2) : .clear,
+                ColorScheme.background
+            ]),
+            startPoint: .bottomLeading,
+            endPoint: .topTrailing
+        )
+    }
+}
+
+struct SearchBarPrepResultsView: View {
+    let prepRecipes: [Prep]
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            ForEach(prepRecipes, id: \.prepIngredientName) { prep in
+                PrepItemView(prep: prep)
+            }
+        }
+    }
+}
+
+#Preview {
+    PrepBibleView()
+}

--- a/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleViewModel.swift
+++ b/MetaCocktailsSwiftData/Views/Prep Bible/PrepBibleViewModel.swift
@@ -1,0 +1,91 @@
+//
+//  PrepBibleViewModel.swift
+//  MetaCocktails
+//
+//  Created on 4/8/25.
+//
+
+import SwiftUI
+import SwiftData
+import Observation
+
+@Observable final class PrepBibleViewModel: ObservableObject {
+
+    private var cachedPrepRecipes: [Prep] = []
+    var searchText = ""
+    var filteredPrepRecipes: [Prep] = []
+    var prepAlphabet: [String] = []
+    var organizedPrepRecipes: [String: [Prep]] = [:]
+    var dataLoaded = false
+    
+ 
+    func loadPrepRecipes(from ingredientBases: [IngredientBase]) {
+        
+        if dataLoaded && !cachedPrepRecipes.isEmpty {
+            return
+        }
+        
+        var uniquePreps: [Prep] = []
+        var seenPrepNames = Set<String>()
+        
+        for base in ingredientBases {
+            if let prep = base.prep, !seenPrepNames.contains(prep.prepIngredientName) {
+                uniquePreps.append(prep)
+                seenPrepNames.insert(prep.prepIngredientName)
+            }
+        }
+        
+        uniquePreps.sort { $0.prepIngredientName < $1.prepIngredientName }
+        
+        cachedPrepRecipes = uniquePreps
+        filteredPrepRecipes = uniquePreps
+        generateAlphabet()
+        organizePrepRecipes()
+        dataLoaded = true
+    }
+    
+    func updateSearch(_ query: String) {
+        searchText = query
+        
+        if query.isEmpty {
+            filteredPrepRecipes = cachedPrepRecipes
+        } else {
+            filteredPrepRecipes = cachedPrepRecipes.filter {
+                $0.prepIngredientName.lowercased().contains(query.lowercased())
+            }
+        }
+    }
+    
+    private func generateAlphabet() {
+        var letters = Set<String>()
+        
+        for prep in cachedPrepRecipes {
+            if let firstChar = prep.prepIngredientName.first {
+                let letter = String(firstChar).uppercased()
+                letters.insert(letter)
+            }
+        }
+        
+        prepAlphabet = Array(letters).sorted()
+    }
+    
+    private func organizePrepRecipes() {
+        organizedPrepRecipes.removeAll()
+        
+        for letter in prepAlphabet {
+            let letterPreps = cachedPrepRecipes.filter {
+                let firstChar = $0.prepIngredientName.prefix(1).uppercased()
+                return firstChar == letter
+            }
+            
+            if !letterPreps.isEmpty {
+                organizedPrepRecipes[letter] = letterPreps
+            }
+        }
+    }
+    
+    func resetSearch() {
+        searchText = ""
+        filteredPrepRecipes = cachedPrepRecipes
+    }
+}

--- a/MetaCocktailsSwiftData/Views/ResourcesView/ResourcesView.swift
+++ b/MetaCocktailsSwiftData/Views/ResourcesView/ResourcesView.swift
@@ -1,0 +1,97 @@
+//
+//  ResourcesView.swift
+//  MetaCocktailsSwiftData
+//
+//  Created by James Menkal on 4/8/25.
+//
+
+
+//
+//  ResourcesView.swift
+//  MetaCocktails
+//
+//  Created on 4/8/25.
+//
+
+import SwiftUI
+
+struct ResourcesView: View {
+    @Environment(\.dismiss) private var dismiss
+    
+    var body: some View {
+        NavigationStack {
+            GeometryReader { outerGeo in
+                ZStack {
+                    ColorScheme.background.ignoresSafeArea()
+                    
+                    VStack(spacing: 0) {
+                        VStack {
+                            NavigationLink {
+                                PrepBibleView()
+                                    .navigationBarBackButtonHidden(true)
+                            } label: {
+                                ZStack {
+                                    BlackGlassBackgroundView()
+                                        .clipShape(RoundedRectangle(cornerRadius: 15))
+                                        .shadow(radius: 5)
+                                    
+                                    VStack(spacing: 15) {
+                                        Image(systemName: "book.fill")
+                                            .resizable()
+                                            .aspectRatio(contentMode: .fit)
+                                            .frame(width: 80, height: 80)
+                                            .foregroundColor(ColorScheme.tintColor)
+                                        
+                                        Text("Prep Bible")
+                                            .font(FontFactory.recipeCardHeader18B)
+                                            .foregroundColor(.primary)
+                                    }
+                                    .padding(30)
+                                }
+                                .frame(width: outerGeo.size.width * 0.8, height: outerGeo.size.height * 0.35)
+                            }
+                        }
+                        .frame(maxHeight: .infinity)
+                        
+                        VStack {
+                            NavigationLink {
+                                AboutUsView()
+                                    .navigationBarBackButtonHidden(true)
+                            } label: {
+                                ZStack {
+                                    BlackGlassBackgroundView()
+                                        .clipShape(RoundedRectangle(cornerRadius: 15))
+                                        .shadow(radius: 5)
+                                    
+                                    VStack(spacing: 15) {
+                                        FirstLoadAnimation(frame: 80,
+                                                           duration: 12,
+                                                           internalColor: ColorScheme.searchBarBackground,
+                                                           externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],
+                                                                                         startPoint: .topLeading,
+                                                                                         endPoint: .bottomTrailing),
+                                                           reverse: false)
+                                        
+                                        Text("About Us")
+                                            .font(FontFactory.recipeCardHeader18B)
+                                            .foregroundColor(.primary)
+                                    }
+                                    .padding(30)
+                                }
+                                .frame(width: outerGeo.size.width * 0.8, height: outerGeo.size.height * 0.35)
+                            }
+                        }
+                        .frame(maxHeight: .infinity)
+                    }
+                    .frame(height: outerGeo.size.height)
+                }
+            }
+            .navigationBarTitleDisplayMode(.inline)
+            .jamesHeaderWithNavigation(title: "Resources", dismiss: dismiss)
+        }
+    }
+}
+
+#Preview {
+    ResourcesView()
+}


### PR DESCRIPTION
![Screenshot 2025-04-08 at 5 27 01 PM](https://github.com/user-attachments/assets/abf31a70-cb52-4e69-8237-8898dce76ae6)
The spinning citrus now navigates to ResourcesView which holds AboutUsView and PrepBibleView.

PrepBibleView is basically just CocktailListView but with only prep items. 
![Screenshot 2025-04-08 at 5 28 58 PM](https://github.com/user-attachments/assets/0b21d01a-2c5e-465d-8125-ffbee22bf157)
Otherwise it all functions the same. I also limited the alphabetNavigation to only include letters that are being utilized to reduce clutter and empty sections with headers. 

I also recycled the cocktail recipe view borders for the recipes because they look nice ands they match the format of the recipes that show up in recipe view.
![Screenshot 2025-04-08 at 5 31 26 PM](https://github.com/user-attachments/assets/d949b7ca-5604-4a50-b4ab-ea5627c07181)

