### PR TITLE
Restore "about us" view

### DIFF
--- a/MetaCocktailsSwiftData/EntryPoint/FirstLaunchLoadingView.swift
+++ b/MetaCocktailsSwiftData/EntryPoint/FirstLaunchLoadingView.swift
@@ -14,7 +14,7 @@ struct FirstLaunchLoadingView: View {
         
         ZStack {
             ColorScheme.background.ignoresSafeArea()
-            FirstLoadAnimation(frame: 200,
+            SpinningLogo(frame: 200,
                                duration: 2,
                                internalColor: Color.primary.mix(with: ColorScheme.tintColor, by: 0.33),
                                externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],

--- a/MetaCocktailsSwiftData/Views/AboutUsView/AboutUsView.swift
+++ b/MetaCocktailsSwiftData/Views/AboutUsView/AboutUsView.swift
@@ -40,7 +40,7 @@ struct AboutUsView: View {
                                 .font(FontFactory.fontBody14)
                                 .multilineTextAlignment(.leading)
                             
-                            FirstLoadAnimation(frame: 140,
+                            SpinningLogo(frame: 140,
                                                duration: 12,
                                                internalColor: Color.primary.mix(with: ColorScheme.tintColor, by: 0.33),
                                                externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],
@@ -126,7 +126,7 @@ struct AboutUsView2: View {
                                 Text(aboutUsTextFirstParagraph)
                                 Text(aboutUsTextSecondParagraph)
                                 
-                                FirstLoadAnimation(frame: 150,
+                                SpinningLogo(frame: 150,
                                                    duration: 8,
                                                    internalColor: Color.primary.mix(with: ColorScheme.tintColor, by: 0.33),
                                                    externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],
@@ -134,7 +134,7 @@ struct AboutUsView2: View {
                                                                                  endPoint: .bottomTrailing),
                                                    reverse: false)
                                 
-                                FirstLoadAnimation(frame: 150,
+                                SpinningLogo(frame: 150,
                                                    duration: 8,
                                                    internalColor: Color.primary.mix(with: Color.brandPrimaryGreen, by: 0.33),
                                                    externalColor: LinearGradient(colors: [Color.brandSecondaryGreen, Color.brandPrimaryGreen, Color.brandSecondaryGreen],

--- a/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
+++ b/MetaCocktailsSwiftData/Views/Cocktail List View/CocktailListView.swift
@@ -140,7 +140,7 @@ struct SearchBarForCocktailListView: View {
                         .navigationBarBackButtonHidden(true)
                 } label: {
                     
-                    FirstLoadAnimation(frame: 46,
+                    SpinningLogo(frame: 46,
                                        duration: 12,
                                        internalColor: ColorScheme.searchBarBackground,
                                        externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],

--- a/MetaCocktailsSwiftData/Views/Loading Indicators/CustomLoadingIndicator.swift
+++ b/MetaCocktailsSwiftData/Views/Loading Indicators/CustomLoadingIndicator.swift
@@ -24,7 +24,7 @@ struct CustomLoadingOverlayModifier: ViewModifier {
     }
 }
 
-struct FirstLoadAnimation: View {
+struct SpinningLogo: View {
     @State private var rotationCircle = 0.0
     let frame: CGFloat
     let duration: TimeInterval

--- a/MetaCocktailsSwiftData/Views/Recipe View/RecipeFrontView.swift
+++ b/MetaCocktailsSwiftData/Views/Recipe View/RecipeFrontView.swift
@@ -69,6 +69,25 @@ struct RecipeFlipCardView: View {
                                         .frame(maxWidth: .infinity, alignment: .center)
                                     
                                 }
+                                
+                                NavigationStack {
+                                    
+                                    NavigationLink {
+                                        AboutUsView()
+                                            .navigationBarBackButtonHidden(true)
+                                    } label: {
+                                        
+                                        SpinningLogo(frame: 46,
+                                                     duration: 12,
+                                                     internalColor: ColorScheme.searchBarBackground,
+                                                     externalColor: LinearGradient(colors: [Color.brandPrimaryOrange, ColorScheme.tintColor, Color.brandPrimaryOrange],
+                                                                                   startPoint: .topLeading,
+                                                                                   endPoint: .bottomTrailing),
+                                                     reverse: false)
+                                        .frame(maxWidth: .infinity, alignment: .trailing)
+                                        
+                                    }
+                                }
                             }
                             .padding(.horizontal)
                             .padding(.vertical, outerGeo.size.height * 0.04)


### PR DESCRIPTION
Forgot the about us view. Since it no longer fits on the cocktailListView without being awkward, it's moved to the recipe view.

Might change this later, but it had to go somewhere